### PR TITLE
build: excluded -nonprod.json files from definition on preview and staging

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -84,7 +84,7 @@ withPipeline(type, product, component) {
       ./bin/add-roles.sh
       ./bin/pull-latest-release-asset.sh civil-ccd-definition civil-ccd-definition.zip
       ./bin/pull-latest-release-asset.sh civil-ccd-definition civil-e2e.zip
-      ./bin/import-ccd-definition.sh
+      ./bin/import-ccd-definition.sh "-e *-nonprod.json"
     """
     env.URL="https://xui-civil-camunda-pr-${CHANGE_ID}.service.core-compute-preview.internal"
     env.CIVIL_SERVICE_URL="http://civil-camunda-pr-${CHANGE_ID}.service.core-compute-preview.internal"
@@ -118,7 +118,7 @@ withPipeline(type, product, component) {
       ./bin/add-roles.sh
       ./bin/pull-latest-release-asset.sh civil-ccd-definition civil-ccd-definition.zip
       ./bin/pull-latest-release-asset.sh civil-ccd-definition civil-e2e.zip
-      ./bin/import-ccd-definition.sh
+      ./bin/import-ccd-definition.sh "-e *-nonprod.json"
     """
     env.URL="https://civil-camunda-xui-staging.aat.platform.hmcts.net"
     env.CIVIL_SERVICE_URL="http://civil-camunda-staging.service.core-compute-aat.internal"

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -103,7 +103,7 @@ withPipeline(type, product, component) {
     dir("${WORKSPACE}/bin") {
       sh """
         eval \$(./variables/load-preview-environment-variables.sh ${CHANGE_ID})
-        ./import-bpmn-diagram.sh ${WORKSPACE}
+        ./import-bpmn-diagram.sh ${WORKSPACE} preview
       """
     }
   }

--- a/bin/import-bpmn-diagram.sh
+++ b/bin/import-bpmn-diagram.sh
@@ -2,10 +2,11 @@
 
 set -eu
 workspace=${1}
+env=${2}
 
 s2sSecret=${S2S_SECRET:-AABBCCDDEEFFGGHH}
 
-if [[ "${2}" == 'prod' ]]; then
+if [[ "${env}" == 'prod' ]]; then
   s2sSecret=${S2S_SECRET_PROD}
 fi
 


### PR DESCRIPTION
### Change description ###

All `-nonprod.json` files are now excluded on staging and preview to ensure we deploy and test production version of CCD definition.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
