### PR TITLE
chore: bump owasp dependenycheck version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id 'checkstyle'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'org.owasp.dependencycheck' version '6.2.2'
+  id 'org.owasp.dependencycheck' version '6.3.2'
   id 'com.github.ben-manes.versions' version '0.39.0'
   id 'org.sonarqube' version '3.3'
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
bump org.owasp.dependencycheck from 6.2.2 to 6.3.2


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
