### PR TITLE
chore: ignore LRspec.json files

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -105,7 +105,7 @@ withPipeline(type, product, component) {
       ./bin/add-roles.sh
       ./bin/pull-latest-release-asset.sh civil-ccd-definition civil-ccd-definition.zip
       ./bin/pull-latest-release-asset.sh civil-ccd-definition civil-e2e.zip
-      ./bin/import-ccd-definition.sh "-e *-nonprod.json"
+      ./bin/import-ccd-definition.sh "-e *-nonprod.json, *LRspec.json"
     """
     env.URL="https://xui-civil-camunda-pr-${CHANGE_ID}.service.core-compute-preview.internal"
     env.CIVIL_SERVICE_URL="http://civil-camunda-pr-${CHANGE_ID}.service.core-compute-preview.internal"
@@ -139,7 +139,7 @@ withPipeline(type, product, component) {
       ./bin/add-roles.sh
       ./bin/pull-latest-release-asset.sh civil-ccd-definition civil-ccd-definition.zip
       ./bin/pull-latest-release-asset.sh civil-ccd-definition civil-e2e.zip
-      ./bin/import-ccd-definition.sh "-e *-nonprod.json"
+      ./bin/import-ccd-definition.sh "-e *-nonprod.json, *LRspec.json"
     """
     env.URL="https://civil-camunda-xui-staging.aat.platform.hmcts.net"
     env.CIVIL_SERVICE_URL="http://civil-camunda-staging.service.core-compute-aat.internal"


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Exclude all LRspec definition files from loading on civil-service PRs


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
