### PR TITLE
build/bump-dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id 'checkstyle'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'org.owasp.dependencycheck' version '6.4.1.1'
+  id 'org.owasp.dependencycheck' version '6.5.0.1'
   id 'com.github.ben-manes.versions' version '0.39.0'
   id 'org.sonarqube' version '3.3'
 }
@@ -65,10 +65,10 @@ allprojects {
       // CVE-2020-26945 - Mishandles deserialization of object streams.
       dependency group: 'org.mybatis', name: 'mybatis', version: '3.5.7'
       dependency group: 'commons-io', name: 'commons-io', version: '2.10.0'
-      dependency group: 'org.springframework.security', name: 'spring-security-crypto', version: '5.5.3'
+      dependency group: 'org.springframework.security', name: 'spring-security-crypto', version: '5.6.0'
     }
     imports {
-      mavenBom 'org.springframework.cloud:spring-cloud-dependencies:2020.0.3'
+      mavenBom 'org.springframework.cloud:spring-cloud-dependencies:2020.0.4'
     }
   }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Bumping the following dependencies:
- spring-security-crypto from 5.5.3 to 5.6.0
- org.owasp.dependencycheck from 6.4.1.1 to 6.5.0.1
- spring-cloud-dependencies from 2020.0.3 to 2020.0.4


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
