### PR TITLE
Add new Flow State for 1V2 same solicitor with different respond

### DIFF
--- a/src/main/resources/camunda/defendant_response.bpmn
+++ b/src/main/resources/camunda/defendant_response.bpmn
@@ -47,7 +47,7 @@
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.FULL_DEFENCE"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_01e5t4p" sourceRef="Gateway_1q9qem9" targetRef="ProceedOfflineForNonDefenceResponse">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.FULL_ADMISSION" || flowState == "MAIN.PART_ADMISSION" || flowState == "MAIN.COUNTER_CLAIM"}</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.FULL_ADMISSION" || flowState == "MAIN.PART_ADMISSION" || flowState == "MAIN.COUNTER_CLAIM" || flowState == "MAIN.DIVERGENT_RESPOND"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_0qgvakl" sourceRef="DefendantResponseCaseHandedOfflineNotifyApplicantSolicitor1" targetRef="NotifyRoboticsOnCaseHandedOffline" />
     <bpmn:endEvent id="Event_15p049m">

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/DefendantResponseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/DefendantResponseTest.java
@@ -47,7 +47,8 @@ class DefendantResponseTest extends BpmnBaseTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"MAIN.FULL_ADMISSION", "MAIN.PART_ADMISSION", "MAIN.COUNTER_CLAIM", "MAIN.DIVERGENT_RESPOND"})
+    @ValueSource(strings = {"MAIN.FULL_ADMISSION", "MAIN.PART_ADMISSION", "MAIN.COUNTER_CLAIM",
+        "MAIN.DIVERGENT_RESPOND"})
     void shouldSuccessfullyCompleteOfflineDefendantResponse(String flowState) {
         //assert process has started
         assertFalse(processInstance.isEnded());

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/DefendantResponseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/DefendantResponseTest.java
@@ -47,7 +47,7 @@ class DefendantResponseTest extends BpmnBaseTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"MAIN.FULL_ADMISSION", "MAIN.PART_ADMISSION", "MAIN.COUNTER_CLAIM"})
+    @ValueSource(strings = {"MAIN.FULL_ADMISSION", "MAIN.PART_ADMISSION", "MAIN.COUNTER_CLAIM", "MAIN.DIVERGENT_RESPOND"})
     void shouldSuccessfullyCompleteOfflineDefendantResponse(String flowState) {
         //assert process has started
         assertFalse(processInstance.isEnded());


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CMC-1789


### Change description ###
Add a new Flowstate "divergent_respond" to support multiparty 1v2 same solicitor claim respond with different respond type

### Related PR: ###
https://github.com/hmcts/civil-ccd-definition/pull/256
https://github.com/hmcts/civil-service/pull/436

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
