### PR TITLE
build/bump dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,14 +61,14 @@ allprojects {
   dependencyManagement {
     dependencies {
       // CVE-2018-10237 - Unbounded memory allocation
-      dependency group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.69'
+      dependency group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.70'
       // CVE-2020-26945 - Mishandles deserialization of object streams.
-      dependency group: 'org.mybatis', name: 'mybatis', version: '3.5.7'
+      dependency group: 'org.mybatis', name: 'mybatis', version: '3.5.8'
       dependency group: 'commons-io', name: 'commons-io', version: '2.10.0'
       dependency group: 'org.springframework.security', name: 'spring-security-crypto', version: '5.6.0'
     }
     imports {
-      mavenBom 'org.springframework.cloud:spring-cloud-dependencies:2020.0.4'
+      mavenBom 'org.springframework.cloud:spring-cloud-dependencies:2021.0.0'
     }
   }
 
@@ -174,7 +174,7 @@ jacocoTestReport.dependsOn {
 
 def versions = [
   junit              : '5.7.2',
-  junitPlatform      : '1.7.2'
+  junitPlatform      : '1.8.2'
 ]
 
 ext.libraries = [


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A

### Change description ###
- bump mybatis from 3.5.7 to 3.5.8
- bump spring-cloud-dependencies from 2020.0.4 to 2021.0.0
- bump bcpkix-jdk15on from 1.69 to 1.70
- bump versions.junitPlatform from 1.7.2 to 1.8.2


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
