### PR TITLE
create sdo camunda diagram

### DIFF
--- a/src/main/resources/camunda/create_sdo.bpmn
+++ b/src/main/resources/camunda/create_sdo.bpmn
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1mvdzjv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:collaboration id="Collaboration_0oe9xk7">
+    <bpmn:participant id="Participant_1st11o5" name="Create sdo" processRef="CREATE_SDO" />
+  </bpmn:collaboration>
+  <bpmn:process id="CREATE_SDO" isExecutable="true">
+    <bpmn:startEvent id="Event_Create_SDO" name="Start">
+      <bpmn:outgoing>Flow_0f1dt36</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1vvatdq" messageRef="Message_0f9tsfp" />
+    </bpmn:startEvent>
+    <bpmn:callActivity id="Activity_StartBusinessProcess" name="Start Business Process" calledElement="StartBusinessProcess">
+      <bpmn:extensionElements>
+        <camunda:in variables="all" />
+        <camunda:out variables="all" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0f1dt36</bpmn:incoming>
+      <bpmn:outgoing>Flow_1l2gbrf</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0w9edp6</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="Event_0miwx8k">
+      <bpmn:incoming>Flow_0w9edp6</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="CreateSDONotifyApplicantSolicitor1" name="Notify applicant solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_APPLICANT_SOLICITOR1_SDO_TRIGGERED</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1l2gbrf</bpmn:incoming>
+      <bpmn:outgoing>Flow_1d6r2uf</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:boundaryEvent id="Event_11hktcj" name="Abort" attachedToRef="Activity_StartBusinessProcess">
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_1npe7kd" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_0f1dt36" sourceRef="Event_Create_SDO" targetRef="Activity_StartBusinessProcess" />
+    <bpmn:sequenceFlow id="Flow_1l2gbrf" sourceRef="Activity_StartBusinessProcess" targetRef="CreateSDONotifyApplicantSolicitor1" />
+    <bpmn:sequenceFlow id="Flow_1d6r2uf" sourceRef="CreateSDONotifyApplicantSolicitor1" targetRef="CreateSDONotifyRespodentSolicitor1" />
+    <bpmn:sequenceFlow id="Flow_0w9edp6" sourceRef="Activity_StartBusinessProcess" targetRef="Event_0miwx8k" />
+    <bpmn:sequenceFlow id="Flow_0adcxbu" sourceRef="CreateSDONotifyRespodentSolicitor1" targetRef="Activity_EndBusinessProcess" />
+    <bpmn:callActivity id="Activity_EndBusinessProcess" name="End Business Process" calledElement="EndBusinessProcess">
+      <bpmn:extensionElements>
+        <camunda:in variables="all" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0adcxbu</bpmn:incoming>
+      <bpmn:outgoing>Flow_1huwtcs</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="Event_EndCreateSDO">
+      <bpmn:incoming>Flow_1huwtcs</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1huwtcs" sourceRef="Activity_EndBusinessProcess" targetRef="Event_EndCreateSDO" />
+    <bpmn:serviceTask id="CreateSDONotifyRespodentSolicitor1" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_SDO_TRIGGERED</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1d6r2uf</bpmn:incoming>
+      <bpmn:outgoing>Flow_0adcxbu</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmn:message id="Message_0f9tsfp" name="CREATE_SDO" />
+  <bpmn:message id="Message_0xkueqz" name="Message_23b65ne" />
+  <bpmn:message id="Message_007m78j" name="Message_0a5d6m8" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0oe9xk7">
+      <bpmndi:BPMNShape id="Participant_1st11o5_di" bpmnElement="Participant_1st11o5" isHorizontal="true">
+        <dc:Bounds x="160" y="80" width="918" height="380" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1huwtcs_di" bpmnElement="Flow_1huwtcs">
+        <di:waypoint x="870" y="250" />
+        <di:waypoint x="932" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0adcxbu_di" bpmnElement="Flow_0adcxbu">
+        <di:waypoint x="710" y="250" />
+        <di:waypoint x="770" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0w9edp6_di" bpmnElement="Flow_0w9edp6">
+        <di:waypoint x="341" y="210" />
+        <di:waypoint x="341" y="148" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1d6r2uf_di" bpmnElement="Flow_1d6r2uf">
+        <di:waypoint x="550" y="250" />
+        <di:waypoint x="610" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1l2gbrf_di" bpmnElement="Flow_1l2gbrf">
+        <di:waypoint x="391" y="250" />
+        <di:waypoint x="450" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0f1dt36_di" bpmnElement="Flow_0f1dt36">
+        <di:waypoint x="239" y="250" />
+        <di:waypoint x="291" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_000hq7z_di" bpmnElement="Event_Create_SDO">
+        <dc:Bounds x="203" y="232" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="209" y="275" width="25" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0dtd5qq_di" bpmnElement="Activity_StartBusinessProcess">
+        <dc:Bounds x="291" y="210" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0miwx8k_di" bpmnElement="Event_0miwx8k">
+        <dc:Bounds x="323" y="112" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0rynuuk_di" bpmnElement="CreateSDONotifyApplicantSolicitor1">
+        <dc:Bounds x="450" y="210" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1vef0vg_di" bpmnElement="Activity_EndBusinessProcess">
+        <dc:Bounds x="770" y="210" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1etg9jk_di" bpmnElement="Event_EndCreateSDO">
+        <dc:Bounds x="932" y="232" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_05dumwf_di" bpmnElement="CreateSDONotifyRespodentSolicitor1">
+        <dc:Bounds x="610" y="210" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_178o507_di" bpmnElement="Event_11hktcj">
+        <dc:Bounds x="322" y="192" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="356" y="183" width="27" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/CreateSDOTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/CreateSDOTest.java
@@ -1,0 +1,69 @@
+package uk.gov.hmcts.reform.civil.bpmn;
+
+import org.camunda.bpm.engine.externaltask.ExternalTask;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class CreateSDOTest extends BpmnBaseTest {
+
+    public static final String MESSAGE_NAME = "CREATE_SDO";
+    public static final String PROCESS_ID = "CREATE_SDO";
+
+    public CreateSDOTest() {
+        super("create_sdo.bpmn", PROCESS_ID);
+    }
+
+    @Test
+    void shouldSuccessfullyCompleteTakeCaseOffline() {
+        //assert process has started
+        assertFalse(processInstance.isEnded());
+
+        //assert message start event
+        assertThat(getProcessDefinitionByMessage(MESSAGE_NAME).getKey()).isEqualTo(PROCESS_ID);
+
+        //complete the start business process
+        ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
+        assertCompleteExternalTask(startBusiness, START_BUSINESS_TOPIC, START_BUSINESS_EVENT, START_BUSINESS_ACTIVITY);
+
+        //complete the notification to applicant
+        ExternalTask applicantNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            applicantNotification,
+            PROCESS_CASE_EVENT,
+            "NOTIFY_APPLICANT_SOLICITOR1_SDO_TRIGGERED",
+            "CreateSDONotifyApplicantSolicitor1"
+        );
+
+        //complete the notification to respondent
+        ExternalTask respondentNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            respondentNotification,
+            PROCESS_CASE_EVENT,
+            "NOTIFY_RESPONDENT_SOLICITOR1_SDO_TRIGGERED",
+            "CreateSDONotifyRespodentSolicitor1"
+        );
+
+        //end business process
+        ExternalTask endBusinessProcess = assertNextExternalTask(END_BUSINESS_PROCESS);
+        completeBusinessProcess(endBusinessProcess);
+
+        assertNoExternalTasksLeft();
+    }
+
+    @Test
+    void shouldAbort_whenStartBusinessProcessThrowsAnError() {
+        //assert process has started
+        assertFalse(processInstance.isEnded());
+
+        //assert message start event
+        assertThat(getProcessDefinitionByMessage(MESSAGE_NAME).getKey()).isEqualTo(PROCESS_ID);
+
+        //fail the start business process
+        ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
+        assertFailExternalTask(startBusiness, START_BUSINESS_TOPIC, START_BUSINESS_EVENT, START_BUSINESS_ACTIVITY);
+
+        assertNoExternalTasksLeft();
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-863


### Change description ###
This PR create a Camunda diagram for the CREATE_SDO journey. This is just a basic diagram which will be added to later, for now we just want to send emails to related parties once an SDO has been triggered on a case.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

![image](https://user-images.githubusercontent.com/94545342/150520379-b008b426-622e-4656-83db-1afae19fe23e.png)
