### PR TITLE
Slim functional tests - Run only Api tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,7 @@ task runSmokeTests(type: Exec, description: 'Runs smoke tests.') {
   commandLine '/usr/bin/yarn', '--silent', 'test:smoke'
 }
 
-task runFunctionalTests(type: Exec, description: 'Runs Api functional tests.') {
+task runApiTests(type: Exec, description: 'Runs Api functional tests.') {
   commandLine '/usr/bin/yarn', '--silent', 'test:api-unspec'
 }
 
@@ -145,7 +145,7 @@ task smoke(description: 'Runs the smoke tests.') {
 }
 
 task functional(description: 'Runs the functional tests.') {
-  dependsOn(inStrictOrder(awaitApplicationReadiness, installDependencies, checkDependenciesIntegrity, runFunctionalTests))
+  dependsOn(inStrictOrder(awaitApplicationReadiness, installDependencies, checkDependenciesIntegrity, runApiTests))
 }
 
 project.tasks['sonarqube'].dependsOn test, jacocoTestReport

--- a/build.gradle
+++ b/build.gradle
@@ -121,8 +121,8 @@ task runSmokeTests(type: Exec, description: 'Runs smoke tests.') {
   commandLine '/usr/bin/yarn', '--silent', 'test:smoke'
 }
 
-task runFunctionalTests(type: Exec, description: 'Runs functional tests.') {
-  commandLine '/usr/bin/yarn', '--silent', 'test:functional'
+task runFunctionalTests(type: Exec, description: 'Runs Api functional tests.') {
+  commandLine '/usr/bin/yarn', '--silent', 'test:api-unspec'
 }
 
 task runRpaHandOffTests(type: Exec, description: 'Runs functional tests.') {


### PR DESCRIPTION
Code coverage is more in Api tests than ui tests and ui screens are not affected by camunda changes. Only events testing should be sufficient
[Civil - Unspec Api coverage.xlsx](https://github.com/hmcts/civil-camunda-bpmn-definition/files/8162144/Civil.-.Unspec.Api.coverage.xlsx)
