### PR TITLE
add jackson databind dependency to address cve

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -194,6 +194,8 @@ ext.libraries = [
 dependencies {
   implementation group: 'org.camunda.bpm', name: 'camunda-external-task-client', version: '7.16.0'
   implementation group: 'org.camunda.bpm.extension.rest', name: 'camunda-rest-client-spring-boot-starter', version: '0.0.6'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.2.1'
+  implementation group: 'com.fasterxml.jackson', name: 'jackson-bom', version: '2.13.2', ext: 'pom'
 
   testImplementation libraries.junit5
   testImplementation group: 'org.camunda.bpm.extension.springboot', name: 'camunda-bpm-spring-boot-starter-test', version: '2.2.0'


### PR DESCRIPTION
### Change description ###
This PR will add the `jackson-databind` dependency. This is to address a CVE that was identified in PR-154: https://build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_Civil%2Fcivil-camunda-bpmn-definition/detail/PR-154/2/pipeline/

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
