### PR TITLE
feat/CMC-1354: adding notification for respondent 2 in claim dismissed

### DIFF
--- a/src/main/resources/camunda/claim_dismissed.bpmn
+++ b/src/main/resources/camunda/claim_dismissed.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0rn46su" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.6.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0rn46su" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.1">
   <bpmn:process id="DISMISS_CLAIM" isExecutable="true">
     <bpmn:startEvent id="Event_0t2zome" name="Start">
       <bpmn:outgoing>Flow_08myj65</bpmn:outgoing>
@@ -23,7 +23,8 @@
         </camunda:inputOutput>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE</bpmn:incoming>
-      <bpmn:incoming>Flow_1dra5bz</bpmn:incoming>
+      <bpmn:incoming>Flow_06dicjn</bpmn:incoming>
+      <bpmn:incoming>Flow_10x6e34</bpmn:incoming>
       <bpmn:outgoing>Flow_1gsn98m</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_1gsn98m" sourceRef="ClaimDismissedNotifyApplicantSolicitor1" targetRef="Activity_0wretog" />
@@ -65,7 +66,7 @@
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE" || flowState == "MAIN.CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_1ver5zr" sourceRef="Activity_0emdthr" targetRef="Gateway_0kj0hok" />
-    <bpmn:sequenceFlow id="Flow_1dra5bz" sourceRef="ClaimDismissedNotifyRespondentSolicitor1" targetRef="ClaimDismissedNotifyApplicantSolicitor1" />
+    <bpmn:sequenceFlow id="Flow_1dra5bz" sourceRef="ClaimDismissedNotifyRespondentSolicitor1" targetRef="Gateway_19b5dvl" />
     <bpmn:serviceTask id="NotifyRoboticsOnCaseHandedOffline" name="Notify RPA on case handed offline" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
@@ -76,15 +77,46 @@
       <bpmn:outgoing>Flow_14zac66</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_14zac66" sourceRef="NotifyRoboticsOnCaseHandedOffline" targetRef="ClaimDismissedNotifyRespondentSolicitor1" />
+    <bpmn:exclusiveGateway id="Gateway_19b5dvl">
+      <bpmn:incoming>Flow_1dra5bz</bpmn:incoming>
+      <bpmn:outgoing>Flow_Two_Respondent_Representatives</bpmn:outgoing>
+      <bpmn:outgoing>Flow_06dicjn</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_Two_Respondent_Representatives" name="Yes" sourceRef="Gateway_19b5dvl" targetRef="ClaimDismissedNotifyRespondentSolicitor2">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.TWO_RESPONDENT_REPRESENTATIVES &amp;&amp; flowFlags.TWO_RESPONDENT_REPRESENTATIVES}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_06dicjn" name="No" sourceRef="Gateway_19b5dvl" targetRef="ClaimDismissedNotifyApplicantSolicitor1">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.ONE_RESPONDENT_REPRESENTATIVE &amp;&amp; flowFlags.ONE_RESPONDENT_REPRESENTATIVE}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_10x6e34" sourceRef="ClaimDismissedNotifyRespondentSolicitor2" targetRef="ClaimDismissedNotifyApplicantSolicitor1" />
+    <bpmn:serviceTask id="ClaimDismissedNotifyRespondentSolicitor2" name="Notify respondent solicitor 2" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR2_FOR_CLAIM_DISMISSED</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_Two_Respondent_Representatives</bpmn:incoming>
+      <bpmn:outgoing>Flow_10x6e34</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:textAnnotation id="TextAnnotation_0i3yd0i">
+      <bpmn:text>Two Respondent Representatives?</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_0ycet74" sourceRef="Gateway_19b5dvl" targetRef="TextAnnotation_0i3yd0i" />
   </bpmn:process>
   <bpmn:message id="Message_0slk3de" name="DISMISS_CLAIM" />
   <bpmn:error id="Error_0t2ju7k" name="StartBusinessAbort" errorCode="ABORT" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="DISMISS_CLAIM">
+      <bpmndi:BPMNShape id="TextAnnotation_0i3yd0i_di" bpmnElement="TextAnnotation_0i3yd0i">
+        <dc:Bounds x="650" y="50" width="120" height="40" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_14zac66_di" bpmnElement="Flow_14zac66">
+        <di:waypoint x="520" y="130" />
+        <di:waypoint x="540" y="130" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1dra5bz_di" bpmnElement="Flow_1dra5bz">
-        <di:waypoint x="710" y="130" />
-        <di:waypoint x="740" y="130" />
-        <di:waypoint x="740" y="220" />
+        <di:waypoint x="640" y="130" />
+        <di:waypoint x="665" y="130" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ver5zr_di" bpmnElement="Flow_1ver5zr">
         <di:waypoint x="330" y="260" />
@@ -92,17 +124,17 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1nu2s7e_di" bpmnElement="Flow_CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE">
         <di:waypoint x="425" y="260" />
-        <di:waypoint x="690" y="260" />
+        <di:waypoint x="840" y="260" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="536" y="265" width="67" height="53" />
+          <dc:Bounds x="617" y="265" width="68" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1nxkg6n_di" bpmnElement="Flow_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE">
         <di:waypoint x="400" y="235" />
         <di:waypoint x="400" y="130" />
-        <di:waypoint x="460" y="130" />
+        <di:waypoint x="420" y="130" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="395" y="80" width="50" height="40" />
+          <dc:Bounds x="349" y="87" width="50" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_08myj65_di" bpmnElement="Flow_08myj65">
@@ -114,16 +146,32 @@
         <di:waypoint x="280" y="168" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1gsn98m_di" bpmnElement="Flow_1gsn98m">
-        <di:waypoint x="790" y="260" />
-        <di:waypoint x="840" y="260" />
+        <di:waypoint x="940" y="260" />
+        <di:waypoint x="980" y="260" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1hce35l_di" bpmnElement="Flow_1hce35l">
-        <di:waypoint x="940" y="260" />
-        <di:waypoint x="1002" y="260" />
+        <di:waypoint x="1080" y="260" />
+        <di:waypoint x="1122" y="260" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_14zac66_di" bpmnElement="Flow_14zac66">
-        <di:waypoint x="560" y="130" />
-        <di:waypoint x="610" y="130" />
+      <bpmndi:BPMNEdge id="Flow_1aqhz9d_di" bpmnElement="Flow_Two_Respondent_Representatives">
+        <di:waypoint x="715" y="130" />
+        <di:waypoint x="750" y="130" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="721" y="113" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10x6e34_di" bpmnElement="Flow_10x6e34">
+        <di:waypoint x="850" y="130" />
+        <di:waypoint x="890" y="130" />
+        <di:waypoint x="890" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06dicjn_di" bpmnElement="Flow_06dicjn">
+        <di:waypoint x="690" y="155" />
+        <di:waypoint x="690" y="230" />
+        <di:waypoint x="840" y="230" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="698" y="190" width="15" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1m02c2o_di" bpmnElement="Event_0t2zome">
         <dc:Bounds x="152" y="242" width="36" height="36" />
@@ -140,21 +188,31 @@
       <bpmndi:BPMNShape id="Gateway_0kj0hok_di" bpmnElement="Gateway_0kj0hok" isMarkerVisible="true">
         <dc:Bounds x="375" y="235" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0r8yo0r_di" bpmnElement="Event_0r8yo0r">
-        <dc:Bounds x="1002" y="242" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1x5rl4x_di" bpmnElement="Activity_0wretog">
-        <dc:Bounds x="840" y="220" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_03lhz3m_di" bpmnElement="ClaimDismissedNotifyApplicantSolicitor1">
-        <dc:Bounds x="690" y="220" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_03ivh0t_di" bpmnElement="NotifyRoboticsOnCaseHandedOffline">
+        <dc:Bounds x="420" y="90" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1n01tzr_di" bpmnElement="ClaimDismissedNotifyRespondentSolicitor1">
-        <dc:Bounds x="610" y="90" width="100" height="80" />
+        <dc:Bounds x="540" y="90" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_03ivh0t_di" bpmnElement="NotifyRoboticsOnCaseHandedOffline">
-        <dc:Bounds x="460" y="90" width="100" height="80" />
+      <bpmndi:BPMNShape id="Gateway_19b5dvl_di" bpmnElement="Gateway_19b5dvl" isMarkerVisible="true">
+        <dc:Bounds x="665" y="105" width="50" height="50" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0r8yo0r_di" bpmnElement="Event_0r8yo0r">
+        <dc:Bounds x="1122" y="242" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1x5rl4x_di" bpmnElement="Activity_0wretog">
+        <dc:Bounds x="980" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_03lhz3m_di" bpmnElement="ClaimDismissedNotifyApplicantSolicitor1">
+        <dc:Bounds x="840" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1dxqaq3_di" bpmnElement="ClaimDismissedNotifyRespondentSolicitor2">
+        <dc:Bounds x="750" y="90" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0ycet74_di" bpmnElement="Association_0ycet74">
+        <di:waypoint x="693" y="108" />
+        <di:waypoint x="696" y="90" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1fn0bf1_di" bpmnElement="Event_1fn0bf1">
         <dc:Bounds x="262" y="202" width="36" height="36" />
         <bpmndi:BPMNLabel>

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ClaimDismissedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ClaimDismissedTest.java
@@ -4,6 +4,10 @@ import org.camunda.bpm.engine.externaltask.ExternalTask;
 import org.camunda.bpm.engine.variable.VariableMap;
 import org.camunda.bpm.engine.variable.Variables;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -91,8 +95,9 @@ class ClaimDismissedTest extends BpmnBaseTest {
         assertNoExternalTasksLeft();
     }
 
-    @Test
-    void shouldNotifyBothParties_whenPastClaimDismissedDeadline() {
+    @ParameterizedTest
+    @ValueSource(strings = {"true", "false"})
+    void shouldNotifyAllParties_whenPastClaimDismissedDeadline(boolean has2RespondentSolicitors) {
         //assert process has started
         assertFalse(processInstance.isEnded());
 
@@ -101,6 +106,9 @@ class ClaimDismissedTest extends BpmnBaseTest {
 
         VariableMap variables = Variables.createVariables();
         variables.putValue("flowState", "MAIN.CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE");
+        variables.put("flowFlags", Map.of(
+            ONE_RESPONDENT_REPRESENTATIVE, !has2RespondentSolicitors,
+            TWO_RESPONDENT_REPRESENTATIVES, has2RespondentSolicitors));
 
         //complete the start business process
         ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
@@ -129,6 +137,17 @@ class ClaimDismissedTest extends BpmnBaseTest {
             "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIM_DISMISSED",
             "ClaimDismissedNotifyRespondentSolicitor1"
         );
+
+        if(has2RespondentSolicitors){
+            //complete the notification to respondent 2
+            ExternalTask respondentTwoNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
+            assertCompleteExternalTask(
+                respondentTwoNotification,
+                PROCESS_CASE_EVENT,
+                "NOTIFY_RESPONDENT_SOLICITOR2_FOR_CLAIM_DISMISSED",
+                "ClaimDismissedNotifyRespondentSolicitor2"
+            );
+        }
 
         //complete the notification to applicant
         ExternalTask applicantNotification = assertNextExternalTask(PROCESS_CASE_EVENT);

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ClaimDismissedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ClaimDismissedTest.java
@@ -138,7 +138,7 @@ class ClaimDismissedTest extends BpmnBaseTest {
             "ClaimDismissedNotifyRespondentSolicitor1"
         );
 
-        if(has2RespondentSolicitors){
+        if (has2RespondentSolicitors) {
             //complete the notification to respondent 2
             ExternalTask respondentTwoNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
             assertCompleteExternalTask(


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CMC-1354


### Change description ###
Change to include respondent solicitor 2 notification in Case dismissed
![image](https://user-images.githubusercontent.com/90403505/160842155-93e0ca49-d7d1-4e94-90f3-a92c9dab9316.png)
- Update of https://github.com/hmcts/civil-camunda-bpmn-definition/pull/149/commits with tests


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
