### PR TITLE
Case Taken Offline Schedular enhanced to cater for multiparty 1 v 2

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -103,4 +103,7 @@
   <suppress>
     <cve>CVE-2022-22950</cve>
   </suppress>
+  <suppress>
+    <cve>CVE-2016-1000027</cve>
+  </suppress>
 </suppressions>

--- a/src/main/resources/camunda/take_case_offline.bpmn
+++ b/src/main/resources/camunda/take_case_offline.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0rn46su" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0rn46su" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.13.0">
   <bpmn:process id="TAKE_CASE_OFFLINE" isExecutable="true">
     <bpmn:startEvent id="Event_StartClaimTakenOffline" name="Start">
       <bpmn:outgoing>Flow_NextStartBusinessProcess</bpmn:outgoing>

--- a/src/main/resources/camunda/take_case_offline.bpmn
+++ b/src/main/resources/camunda/take_case_offline.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0rn46su" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.5.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0rn46su" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <bpmn:process id="TAKE_CASE_OFFLINE" isExecutable="true">
     <bpmn:startEvent id="Event_StartClaimTakenOffline" name="Start">
       <bpmn:outgoing>Flow_NextStartBusinessProcess</bpmn:outgoing>
@@ -51,19 +51,41 @@
         </camunda:inputOutput>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_NextEndBusinessProcess</bpmn:incoming>
-      <bpmn:outgoing>Flow_1hq815y</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1n9mb8u</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1hq815y" sourceRef="TakeCaseOfflineNotifyRespondentSolicitor1" targetRef="TakeCaseOfflineNotifyApplicantSolicitor1" />
     <bpmn:serviceTask id="TakeCaseOfflineNotifyApplicantSolicitor1" name="Notify applicant solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
           <camunda:inputParameter name="caseEvent">NOTIFY_APPLICANT_SOLICITOR1_FOR_CASE_TAKEN_OFFLINE</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1hq815y</bpmn:incoming>
+      <bpmn:incoming>Flow_0wuhpfb</bpmn:incoming>
+      <bpmn:incoming>Flow_0hs292h</bpmn:incoming>
       <bpmn:outgoing>Flow_0uljtsx</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_0uljtsx" sourceRef="TakeCaseOfflineNotifyApplicantSolicitor1" targetRef="Activity_EndBusinessProcess" />
+    <bpmn:exclusiveGateway id="Gateway_Two_Representetives">
+      <bpmn:incoming>Flow_1n9mb8u</bpmn:incoming>
+      <bpmn:outgoing>Flow_0wuhpfb</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0lq9pff</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1n9mb8u" sourceRef="TakeCaseOfflineNotifyRespondentSolicitor1" targetRef="Gateway_Two_Representetives" />
+    <bpmn:sequenceFlow id="Flow_0wuhpfb" sourceRef="Gateway_Two_Representetives" targetRef="TakeCaseOfflineNotifyApplicantSolicitor1">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.ONE_RESPONDENT_REPRESENTATIVE &amp;&amp; flowFlags.ONE_RESPONDENT_REPRESENTATIVE}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:serviceTask id="TakeCaseOfflineNotifyRespondentSolicitor2" name="Notify respondent solicitor 2" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR2_FOR_CASE_TAKEN_OFFLINE</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0lq9pff</bpmn:incoming>
+      <bpmn:outgoing>Flow_0hs292h</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0lq9pff" name="1v2 (Two Representatives)" sourceRef="Gateway_Two_Representetives" targetRef="TakeCaseOfflineNotifyRespondentSolicitor2">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.TWO_RESPONDENT_REPRESENTATIVES &amp;&amp; flowFlags.TWO_RESPONDENT_REPRESENTATIVES}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0hs292h" sourceRef="TakeCaseOfflineNotifyRespondentSolicitor2" targetRef="TakeCaseOfflineNotifyApplicantSolicitor1" />
   </bpmn:process>
   <bpmn:message id="Message_0slk3de" name="TAKE_CASE_OFFLINE" />
   <bpmn:error id="Error_0t2ju7k" name="StartBusinessAbort" errorCode="ABORT" />
@@ -86,16 +108,32 @@
         <di:waypoint x="280" y="118" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1hce35l_di" bpmnElement="Flow_NextEndEvent">
-        <di:waypoint x="880" y="210" />
-        <di:waypoint x="912" y="210" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1hq815y_di" bpmnElement="Flow_1hq815y">
-        <di:waypoint x="600" y="210" />
-        <di:waypoint x="640" y="210" />
+        <di:waypoint x="940" y="210" />
+        <di:waypoint x="972" y="210" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0uljtsx_di" bpmnElement="Flow_0uljtsx">
-        <di:waypoint x="740" y="210" />
-        <di:waypoint x="780" y="210" />
+        <di:waypoint x="800" y="210" />
+        <di:waypoint x="840" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1n9mb8u_di" bpmnElement="Flow_1n9mb8u">
+        <di:waypoint x="600" y="210" />
+        <di:waypoint x="625" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0wuhpfb_di" bpmnElement="Flow_0wuhpfb">
+        <di:waypoint x="675" y="210" />
+        <di:waypoint x="700" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0lq9pff_di" bpmnElement="Flow_0lq9pff">
+        <di:waypoint x="650" y="185" />
+        <di:waypoint x="650" y="100" />
+        <di:waypoint x="700" y="100" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="558" y="126" width="84" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0hs292h_di" bpmnElement="Flow_0hs292h">
+        <di:waypoint x="750" y="140" />
+        <di:waypoint x="750" y="170" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1m02c2o_di" bpmnElement="Event_StartClaimTakenOffline">
         <dc:Bounds x="152" y="192" width="36" height="36" />
@@ -112,17 +150,23 @@
       <bpmndi:BPMNShape id="Activity_08ndbvb_di" bpmnElement="NotifyRoboticsOnCaseHandedOffline">
         <dc:Bounds x="370" y="170" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0r8yo0r_di" bpmnElement="Event_EndClaimTakenOffline">
-        <dc:Bounds x="912" y="192" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1x5rl4x_di" bpmnElement="Activity_EndBusinessProcess">
-        <dc:Bounds x="780" y="170" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0lrzkzm_di" bpmnElement="TakeCaseOfflineNotifyRespondentSolicitor1">
         <dc:Bounds x="500" y="170" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0o6ykyq_di" bpmnElement="Gateway_Two_Representetives" isMarkerVisible="true">
+        <dc:Bounds x="625" y="185" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0r8yo0r_di" bpmnElement="Event_EndClaimTakenOffline">
+        <dc:Bounds x="972" y="192" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1x5rl4x_di" bpmnElement="Activity_EndBusinessProcess">
+        <dc:Bounds x="840" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1huplho_di" bpmnElement="TakeCaseOfflineNotifyApplicantSolicitor1">
-        <dc:Bounds x="640" y="170" width="100" height="80" />
+        <dc:Bounds x="700" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_00j2ajh_di" bpmnElement="TakeCaseOfflineNotifyRespondentSolicitor2">
+        <dc:Bounds x="700" y="60" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1fn0bf1_di" bpmnElement="Event_1fn0bf1">
         <dc:Bounds x="262" y="152" width="36" height="36" />

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/TakeCaseOfflineTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/TakeCaseOfflineTest.java
@@ -1,7 +1,13 @@
 package uk.gov.hmcts.reform.civil.bpmn;
 
 import org.camunda.bpm.engine.externaltask.ExternalTask;
+import org.camunda.bpm.engine.variable.VariableMap;
+import org.camunda.bpm.engine.variable.Variables;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -18,17 +24,29 @@ class TakeCaseOfflineTest extends BpmnBaseTest {
         super("take_case_offline.bpmn", "TAKE_CASE_OFFLINE");
     }
 
-    @Test
-    void shouldSuccessfullyCompleteTakeCaseOffline() {
+    @ParameterizedTest
+    @ValueSource(strings = {"true", "false"})
+    void shouldSuccessfullyCompleteTakeCaseOffline(boolean twoRepresentatives) {
         //assert process has started
         assertFalse(processInstance.isEnded());
 
         //assert message start event
         assertThat(getProcessDefinitionByMessage(MESSAGE_NAME).getKey()).isEqualTo(PROCESS_ID);
 
+        VariableMap variables = Variables.createVariables();
+        variables.put("flowFlags", Map.of(
+            ONE_RESPONDENT_REPRESENTATIVE, !twoRepresentatives,
+            TWO_RESPONDENT_REPRESENTATIVES, twoRepresentatives));
+
         //complete the start business process
         ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
-        assertCompleteExternalTask(startBusiness, START_BUSINESS_TOPIC, START_BUSINESS_EVENT, START_BUSINESS_ACTIVITY);
+        assertCompleteExternalTask(
+            startBusiness,
+            START_BUSINESS_TOPIC,
+            START_BUSINESS_EVENT,
+            START_BUSINESS_ACTIVITY,
+            variables
+        );
 
         //complete the RPA notification
         ExternalTask rpaNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
@@ -39,13 +57,23 @@ class TakeCaseOfflineTest extends BpmnBaseTest {
             NOTIFY_RPA_ON_CASE_HANDED_OFFLINE_ACTIVITY_ID
         );
 
-        //complete the notification to respondent
+        //complete the notification to respondent 1
         ExternalTask respondentNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
         assertCompleteExternalTask(respondentNotification,
                                    PROCESS_CASE_EVENT,
                                    "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CASE_TAKEN_OFFLINE",
                                    "TakeCaseOfflineNotifyRespondentSolicitor1"
         );
+
+        if(twoRepresentatives) {
+            //complete the notification to respondent 2
+            ExternalTask respondent2Notification = assertNextExternalTask(PROCESS_CASE_EVENT);
+            assertCompleteExternalTask(respondent2Notification,
+                                       PROCESS_CASE_EVENT,
+                                       "NOTIFY_RESPONDENT_SOLICITOR2_FOR_CASE_TAKEN_OFFLINE",
+                                       "TakeCaseOfflineNotifyRespondentSolicitor2"
+            );
+        }
 
         //complete the notification to applicant
         ExternalTask applicantNotification = assertNextExternalTask(PROCESS_CASE_EVENT);

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/TakeCaseOfflineTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/TakeCaseOfflineTest.java
@@ -65,7 +65,7 @@ class TakeCaseOfflineTest extends BpmnBaseTest {
                                    "TakeCaseOfflineNotifyRespondentSolicitor1"
         );
 
-        if(twoRepresentatives) {
+        if (twoRepresentatives) {
             //complete the notification to respondent 2
             ExternalTask respondent2Notification = assertNextExternalTask(PROCESS_CASE_EVENT);
             assertCompleteExternalTask(respondent2Notification,


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CMC-2033

- Added  notify respondent 2 solicitors task to TAKE_CASE_OFFLINE process.

<img width="954" alt="Screenshot 2022-04-21 at 09 31 32" src="https://user-images.githubusercontent.com/90632240/164414387-8a0ca8a1-d1db-4167-b64b-a80611534626.png">

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
