### PR TITLE
CIV-4632: camunda change

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -132,7 +132,7 @@
   <suppress>
     <cve>CVE-2022-33915</cve>
   </suppress>
-  <suppress>
+  <suppress until="2022-10-01">
     <cve>CVE-2022-25857</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -132,4 +132,7 @@
   <suppress>
     <cve>CVE-2022-33915</cve>
   </suppress>
+  <suppress>
+    <cve>CVE-2022-25857</cve>
+  </suppress>
 </suppressions>

--- a/src/main/resources/camunda/claim_dismissed.bpmn
+++ b/src/main/resources/camunda/claim_dismissed.bpmn
@@ -27,7 +27,7 @@
       <bpmn:incoming>Flow_10x6e34</bpmn:incoming>
       <bpmn:outgoing>Flow_1gsn98m</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1gsn98m" sourceRef="ClaimDismissedNotifyApplicantSolicitor1" targetRef="Activity_1ov4t1h" />
+    <bpmn:sequenceFlow id="Flow_1gsn98m" sourceRef="ClaimDismissedNotifyApplicantSolicitor1" targetRef="NotifyRoboticsOnCaseHandedOffline" />
     <bpmn:callActivity id="Activity_0emdthr" name="Start Business Process" calledElement="StartBusinessProcess">
       <bpmn:extensionElements>
         <camunda:in variables="all" />
@@ -88,7 +88,7 @@
       <bpmn:incoming>Flow_Two_Respondent_Representatives</bpmn:incoming>
       <bpmn:outgoing>Flow_10x6e34</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:serviceTask id="Activity_1ov4t1h" name="Notify RPA on case handed offline" camunda:type="external" camunda:topic="processCaseEvent">
+    <bpmn:serviceTask id="NotifyRoboticsOnCaseHandedOffline" name="Notify RPA on case handed offline" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
           <camunda:inputParameter name="caseEvent">NOTIFY_RPA_ON_CASE_HANDED_OFFLINE</camunda:inputParameter>
@@ -97,7 +97,7 @@
       <bpmn:incoming>Flow_1gsn98m</bpmn:incoming>
       <bpmn:outgoing>Flow_1n57cdt</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1n57cdt" sourceRef="Activity_1ov4t1h" targetRef="Activity_0wretog" />
+    <bpmn:sequenceFlow id="Flow_1n57cdt" sourceRef="NotifyRoboticsOnCaseHandedOffline" targetRef="Activity_0wretog" />
     <bpmn:textAnnotation id="TextAnnotation_0i3yd0i">
       <bpmn:text>Two Respondent Representatives?</bpmn:text>
     </bpmn:textAnnotation>
@@ -107,6 +107,10 @@
   <bpmn:error id="Error_0t2ju7k" name="StartBusinessAbort" errorCode="ABORT" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="DISMISS_CLAIM">
+      <bpmndi:BPMNEdge id="Flow_1n57cdt_di" bpmnElement="Flow_1n57cdt">
+        <di:waypoint x="1080" y="260" />
+        <di:waypoint x="1150" y="260" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_10x6e34_di" bpmnElement="Flow_10x6e34">
         <di:waypoint x="800" y="130" />
         <di:waypoint x="890" y="130" />
@@ -168,21 +172,11 @@
         <di:waypoint x="1250" y="260" />
         <di:waypoint x="1272" y="260" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1n57cdt_di" bpmnElement="Flow_1n57cdt">
-        <di:waypoint x="1080" y="260" />
-        <di:waypoint x="1150" y="260" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1m02c2o_di" bpmnElement="Event_0t2zome">
         <dc:Bounds x="152" y="242" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="158" y="285" width="24" height="14" />
         </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1nsmt51_di" bpmnElement="Event_1nsmt51">
-        <dc:Bounds x="262" y="132" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="TextAnnotation_0i3yd0i_di" bpmnElement="TextAnnotation_0i3yd0i">
-        <dc:Bounds x="650" y="50" width="120" height="40" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0r8yo0r_di" bpmnElement="Event_0r8yo0r">
         <dc:Bounds x="1272" y="242" width="36" height="36" />
@@ -190,11 +184,20 @@
       <bpmndi:BPMNShape id="Activity_1x5rl4x_di" bpmnElement="Activity_0wretog">
         <dc:Bounds x="1150" y="220" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1ov4t1h_di" bpmnElement="Activity_1ov4t1h">
-        <dc:Bounds x="980" y="220" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_03lhz3m_di" bpmnElement="ClaimDismissedNotifyApplicantSolicitor1">
+        <dc:Bounds x="840" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0emdthr_di" bpmnElement="Activity_0emdthr">
+        <dc:Bounds x="210" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1nsmt51_di" bpmnElement="Event_1nsmt51">
+        <dc:Bounds x="262" y="132" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1n01tzr_di" bpmnElement="ClaimDismissedNotifyRespondentSolicitor1">
         <dc:Bounds x="450" y="90" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0kj0hok_di" bpmnElement="Gateway_0kj0hok" isMarkerVisible="true">
+        <dc:Bounds x="395" y="235" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_19b5dvl_di" bpmnElement="Gateway_19b5dvl" isMarkerVisible="true">
         <dc:Bounds x="625" y="105" width="50" height="50" />
@@ -202,25 +205,22 @@
       <bpmndi:BPMNShape id="Activity_1dxqaq3_di" bpmnElement="ClaimDismissedNotifyRespondentSolicitor2">
         <dc:Bounds x="700" y="90" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_03lhz3m_di" bpmnElement="ClaimDismissedNotifyApplicantSolicitor1">
-        <dc:Bounds x="840" y="220" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_1ov4t1h_di" bpmnElement="NotifyRoboticsOnCaseHandedOffline">
+        <dc:Bounds x="980" y="220" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0emdthr_di" bpmnElement="Activity_0emdthr">
-        <dc:Bounds x="210" y="220" width="100" height="80" />
+      <bpmndi:BPMNShape id="TextAnnotation_0i3yd0i_di" bpmnElement="TextAnnotation_0i3yd0i">
+        <dc:Bounds x="650" y="50" width="120" height="40" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0kj0hok_di" bpmnElement="Gateway_0kj0hok" isMarkerVisible="true">
-        <dc:Bounds x="395" y="235" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Association_0ycet74_di" bpmnElement="Association_0ycet74">
-        <di:waypoint x="661" y="116" />
-        <di:waypoint x="682" y="90" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1fn0bf1_di" bpmnElement="Event_1fn0bf1">
         <dc:Bounds x="242" y="202" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="276" y="183" width="27" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0ycet74_di" bpmnElement="Association_0ycet74">
+        <di:waypoint x="661" y="116" />
+        <di:waypoint x="682" y="90" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/src/main/resources/camunda/claim_dismissed.bpmn
+++ b/src/main/resources/camunda/claim_dismissed.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0rn46su" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.1">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0rn46su" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
   <bpmn:process id="DISMISS_CLAIM" isExecutable="true">
     <bpmn:startEvent id="Event_0t2zome" name="Start">
       <bpmn:outgoing>Flow_08myj65</bpmn:outgoing>
@@ -13,7 +13,7 @@
       <bpmn:extensionElements>
         <camunda:in variables="all" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1gsn98m</bpmn:incoming>
+      <bpmn:incoming>Flow_1n57cdt</bpmn:incoming>
       <bpmn:outgoing>Flow_1hce35l</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:serviceTask id="ClaimDismissedNotifyApplicantSolicitor1" name="Notify applicant solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
@@ -27,7 +27,7 @@
       <bpmn:incoming>Flow_10x6e34</bpmn:incoming>
       <bpmn:outgoing>Flow_1gsn98m</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1gsn98m" sourceRef="ClaimDismissedNotifyApplicantSolicitor1" targetRef="Activity_0wretog" />
+    <bpmn:sequenceFlow id="Flow_1gsn98m" sourceRef="ClaimDismissedNotifyApplicantSolicitor1" targetRef="Activity_1ov4t1h" />
     <bpmn:callActivity id="Activity_0emdthr" name="Start Business Process" calledElement="StartBusinessProcess">
       <bpmn:extensionElements>
         <camunda:in variables="all" />
@@ -51,7 +51,7 @@
           <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIM_DISMISSED</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_14zac66</bpmn:incoming>
+      <bpmn:incoming>Flow_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE</bpmn:incoming>
       <bpmn:outgoing>Flow_1dra5bz</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:exclusiveGateway id="Gateway_0kj0hok">
@@ -59,7 +59,7 @@
       <bpmn:outgoing>Flow_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE</bpmn:outgoing>
       <bpmn:outgoing>Flow_CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE" name="past claim dismissed deadline" sourceRef="Gateway_0kj0hok" targetRef="NotifyRoboticsOnCaseHandedOffline">
+    <bpmn:sequenceFlow id="Flow_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE" name="past claim dismissed deadline" sourceRef="Gateway_0kj0hok" targetRef="ClaimDismissedNotifyRespondentSolicitor1">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE" name="past claim (or claim details) notification deadline" sourceRef="Gateway_0kj0hok" targetRef="ClaimDismissedNotifyApplicantSolicitor1">
@@ -67,16 +67,6 @@
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_1ver5zr" sourceRef="Activity_0emdthr" targetRef="Gateway_0kj0hok" />
     <bpmn:sequenceFlow id="Flow_1dra5bz" sourceRef="ClaimDismissedNotifyRespondentSolicitor1" targetRef="Gateway_19b5dvl" />
-    <bpmn:serviceTask id="NotifyRoboticsOnCaseHandedOffline" name="Notify RPA on case handed offline" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_RPA_ON_CASE_HANDED_OFFLINE</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE</bpmn:incoming>
-      <bpmn:outgoing>Flow_14zac66</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_14zac66" sourceRef="NotifyRoboticsOnCaseHandedOffline" targetRef="ClaimDismissedNotifyRespondentSolicitor1" />
     <bpmn:exclusiveGateway id="Gateway_19b5dvl">
       <bpmn:incoming>Flow_1dra5bz</bpmn:incoming>
       <bpmn:outgoing>Flow_Two_Respondent_Representatives</bpmn:outgoing>
@@ -98,6 +88,16 @@
       <bpmn:incoming>Flow_Two_Respondent_Representatives</bpmn:incoming>
       <bpmn:outgoing>Flow_10x6e34</bpmn:outgoing>
     </bpmn:serviceTask>
+    <bpmn:serviceTask id="Activity_1ov4t1h" name="Notify RPA on case handed offline" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_RPA_ON_CASE_HANDED_OFFLINE</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1gsn98m</bpmn:incoming>
+      <bpmn:outgoing>Flow_1n57cdt</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1n57cdt" sourceRef="Activity_1ov4t1h" targetRef="Activity_0wretog" />
     <bpmn:textAnnotation id="TextAnnotation_0i3yd0i">
       <bpmn:text>Two Respondent Representatives?</bpmn:text>
     </bpmn:textAnnotation>
@@ -107,42 +107,57 @@
   <bpmn:error id="Error_0t2ju7k" name="StartBusinessAbort" errorCode="ABORT" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="DISMISS_CLAIM">
-      <bpmndi:BPMNShape id="TextAnnotation_0i3yd0i_di" bpmnElement="TextAnnotation_0i3yd0i">
-        <dc:Bounds x="650" y="50" width="120" height="40" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_14zac66_di" bpmnElement="Flow_14zac66">
-        <di:waypoint x="520" y="130" />
-        <di:waypoint x="540" y="130" />
+      <bpmndi:BPMNEdge id="Flow_10x6e34_di" bpmnElement="Flow_10x6e34">
+        <di:waypoint x="800" y="130" />
+        <di:waypoint x="890" y="130" />
+        <di:waypoint x="890" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06dicjn_di" bpmnElement="Flow_06dicjn">
+        <di:waypoint x="650" y="155" />
+        <di:waypoint x="650" y="240" />
+        <di:waypoint x="840" y="240" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="658" y="196" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1aqhz9d_di" bpmnElement="Flow_Two_Respondent_Representatives">
+        <di:waypoint x="675" y="130" />
+        <di:waypoint x="700" y="130" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="677" y="113" width="18" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1dra5bz_di" bpmnElement="Flow_1dra5bz">
-        <di:waypoint x="640" y="130" />
-        <di:waypoint x="665" y="130" />
+        <di:waypoint x="550" y="130" />
+        <di:waypoint x="625" y="130" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ver5zr_di" bpmnElement="Flow_1ver5zr">
-        <di:waypoint x="330" y="260" />
-        <di:waypoint x="375" y="260" />
+        <di:waypoint x="310" y="260" />
+        <di:waypoint x="395" y="260" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1nu2s7e_di" bpmnElement="Flow_CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE">
-        <di:waypoint x="425" y="260" />
+        <di:waypoint x="445" y="260" />
         <di:waypoint x="840" y="260" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="617" y="265" width="68" height="53" />
+          <dc:Bounds x="627" y="265" width="68" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1nxkg6n_di" bpmnElement="Flow_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE">
-        <di:waypoint x="400" y="235" />
-        <di:waypoint x="400" y="130" />
+        <di:waypoint x="420" y="235" />
         <di:waypoint x="420" y="130" />
+        <di:waypoint x="450" y="130" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="349" y="87" width="50" height="40" />
+          <dc:Bounds x="355" y="140" width="50" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_08myj65_di" bpmnElement="Flow_08myj65">
         <di:waypoint x="188" y="260" />
-        <di:waypoint x="230" y="260" />
+        <di:waypoint x="210" y="260" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0yvpi10_di" bpmnElement="Flow_0yvpi10">
-        <di:waypoint x="280" y="202" />
+        <di:waypoint x="260" y="202" />
+        <di:waypoint x="260" y="185" />
+        <di:waypoint x="280" y="185" />
         <di:waypoint x="280" y="168" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1gsn98m_di" bpmnElement="Flow_1gsn98m">
@@ -150,28 +165,12 @@
         <di:waypoint x="980" y="260" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1hce35l_di" bpmnElement="Flow_1hce35l">
+        <di:waypoint x="1250" y="260" />
+        <di:waypoint x="1272" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1n57cdt_di" bpmnElement="Flow_1n57cdt">
         <di:waypoint x="1080" y="260" />
-        <di:waypoint x="1122" y="260" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1aqhz9d_di" bpmnElement="Flow_Two_Respondent_Representatives">
-        <di:waypoint x="715" y="130" />
-        <di:waypoint x="750" y="130" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="721" y="113" width="18" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_10x6e34_di" bpmnElement="Flow_10x6e34">
-        <di:waypoint x="850" y="130" />
-        <di:waypoint x="890" y="130" />
-        <di:waypoint x="890" y="220" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_06dicjn_di" bpmnElement="Flow_06dicjn">
-        <di:waypoint x="690" y="155" />
-        <di:waypoint x="690" y="230" />
-        <di:waypoint x="840" y="230" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="698" y="190" width="15" height="14" />
-        </bpmndi:BPMNLabel>
+        <di:waypoint x="1150" y="260" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1m02c2o_di" bpmnElement="Event_0t2zome">
         <dc:Bounds x="152" y="242" width="36" height="36" />
@@ -179,44 +178,47 @@
           <dc:Bounds x="158" y="285" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0emdthr_di" bpmnElement="Activity_0emdthr">
-        <dc:Bounds x="230" y="220" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1nsmt51_di" bpmnElement="Event_1nsmt51">
         <dc:Bounds x="262" y="132" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0kj0hok_di" bpmnElement="Gateway_0kj0hok" isMarkerVisible="true">
-        <dc:Bounds x="375" y="235" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_03ivh0t_di" bpmnElement="NotifyRoboticsOnCaseHandedOffline">
-        <dc:Bounds x="420" y="90" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1n01tzr_di" bpmnElement="ClaimDismissedNotifyRespondentSolicitor1">
-        <dc:Bounds x="540" y="90" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_19b5dvl_di" bpmnElement="Gateway_19b5dvl" isMarkerVisible="true">
-        <dc:Bounds x="665" y="105" width="50" height="50" />
+      <bpmndi:BPMNShape id="TextAnnotation_0i3yd0i_di" bpmnElement="TextAnnotation_0i3yd0i">
+        <dc:Bounds x="650" y="50" width="120" height="40" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0r8yo0r_di" bpmnElement="Event_0r8yo0r">
-        <dc:Bounds x="1122" y="242" width="36" height="36" />
+        <dc:Bounds x="1272" y="242" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1x5rl4x_di" bpmnElement="Activity_0wretog">
+        <dc:Bounds x="1150" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ov4t1h_di" bpmnElement="Activity_1ov4t1h">
         <dc:Bounds x="980" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1n01tzr_di" bpmnElement="ClaimDismissedNotifyRespondentSolicitor1">
+        <dc:Bounds x="450" y="90" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_19b5dvl_di" bpmnElement="Gateway_19b5dvl" isMarkerVisible="true">
+        <dc:Bounds x="625" y="105" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1dxqaq3_di" bpmnElement="ClaimDismissedNotifyRespondentSolicitor2">
+        <dc:Bounds x="700" y="90" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_03lhz3m_di" bpmnElement="ClaimDismissedNotifyApplicantSolicitor1">
         <dc:Bounds x="840" y="220" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1dxqaq3_di" bpmnElement="ClaimDismissedNotifyRespondentSolicitor2">
-        <dc:Bounds x="750" y="90" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_0emdthr_di" bpmnElement="Activity_0emdthr">
+        <dc:Bounds x="210" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0kj0hok_di" bpmnElement="Gateway_0kj0hok" isMarkerVisible="true">
+        <dc:Bounds x="395" y="235" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Association_0ycet74_di" bpmnElement="Association_0ycet74">
-        <di:waypoint x="693" y="108" />
-        <di:waypoint x="696" y="90" />
+        <di:waypoint x="661" y="116" />
+        <di:waypoint x="682" y="90" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1fn0bf1_di" bpmnElement="Event_1fn0bf1">
-        <dc:Bounds x="262" y="202" width="36" height="36" />
+        <dc:Bounds x="242" y="202" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="296" y="183" width="27" height="14" />
+          <dc:Bounds x="276" y="183" width="27" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ClaimDismissedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ClaimDismissedTest.java
@@ -91,10 +91,11 @@ class ClaimDismissedTest extends BpmnBaseTest {
 
         //Notify RPA - Handed Offline
         ExternalTask notifyRpaHandedOffline = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(notifyRpaHandedOffline,
-                                   PROCESS_CASE_EVENT,
-                                   NOTIFY_RPA_ON_CASE_HANDED_OFFLINE,
-                                   NOTIFY_RPA_ON_CASE_HANDED_OFFLINE_ACTIVITY_ID
+        assertCompleteExternalTask(
+            notifyRpaHandedOffline,
+            PROCESS_CASE_EVENT,
+            NOTIFY_RPA_ON_CASE_HANDED_OFFLINE,
+            NOTIFY_RPA_ON_CASE_HANDED_OFFLINE_ACTIVITY_ID
         );
 
         //end business process

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ClaimDismissedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ClaimDismissedTest.java
@@ -18,6 +18,7 @@ class ClaimDismissedTest extends BpmnBaseTest {
     public static final String PROCESS_ID = "DISMISS_CLAIM";
     private static final String NOTIFY_RPA_ON_CASE_HANDED_OFFLINE = "NOTIFY_RPA_ON_CASE_HANDED_OFFLINE";
     private static final String NOTIFY_RPA_ON_CASE_HANDED_OFFLINE_ACTIVITY_ID = "NotifyRoboticsOnCaseHandedOffline";
+
     public ClaimDismissedTest() {
         super("claim_dismissed.bpmn", "DISMISS_CLAIM");
     }
@@ -50,6 +51,15 @@ class ClaimDismissedTest extends BpmnBaseTest {
             PROCESS_CASE_EVENT,
             "NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_DISMISSED",
             "ClaimDismissedNotifyApplicantSolicitor1"
+        );
+
+        //complete the RPA notification
+        ExternalTask rpaNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            rpaNotification,
+            PROCESS_CASE_EVENT,
+            "NOTIFY_RPA_ON_CASE_HANDED_OFFLINE",
+            "NotifyRoboticsOnCaseHandedOffline"
         );
 
         //end business process
@@ -118,7 +128,8 @@ class ClaimDismissedTest extends BpmnBaseTest {
         variables.putValue("flowState", "MAIN.CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE");
         variables.put("flowFlags", Map.of(
             ONE_RESPONDENT_REPRESENTATIVE, !has2RespondentSolicitors,
-            TWO_RESPONDENT_REPRESENTATIVES, has2RespondentSolicitors));
+            TWO_RESPONDENT_REPRESENTATIVES, has2RespondentSolicitors
+        ));
 
         //complete the start business process
         ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
@@ -128,15 +139,6 @@ class ClaimDismissedTest extends BpmnBaseTest {
             START_BUSINESS_EVENT,
             START_BUSINESS_ACTIVITY,
             variables
-        );
-
-        //complete the RPA notification
-        ExternalTask rpaNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            rpaNotification,
-            PROCESS_CASE_EVENT,
-            "NOTIFY_RPA_ON_CASE_HANDED_OFFLINE",
-            "NotifyRoboticsOnCaseHandedOffline"
         );
 
         //complete the notification to respondent
@@ -166,6 +168,15 @@ class ClaimDismissedTest extends BpmnBaseTest {
             PROCESS_CASE_EVENT,
             "NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_DISMISSED",
             "ClaimDismissedNotifyApplicantSolicitor1"
+        );
+
+        //complete the RPA notification
+        ExternalTask rpaNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            rpaNotification,
+            PROCESS_CASE_EVENT,
+            "NOTIFY_RPA_ON_CASE_HANDED_OFFLINE",
+            "NotifyRoboticsOnCaseHandedOffline"
         );
 
         //end business process

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ClaimDismissedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ClaimDismissedTest.java
@@ -16,7 +16,8 @@ class ClaimDismissedTest extends BpmnBaseTest {
 
     public static final String MESSAGE_NAME = "DISMISS_CLAIM";
     public static final String PROCESS_ID = "DISMISS_CLAIM";
-
+    private static final String NOTIFY_RPA_ON_CASE_HANDED_OFFLINE = "NOTIFY_RPA_ON_CASE_HANDED_OFFLINE";
+    private static final String NOTIFY_RPA_ON_CASE_HANDED_OFFLINE_ACTIVITY_ID = "NotifyRoboticsOnCaseHandedOffline";
     public ClaimDismissedTest() {
         super("claim_dismissed.bpmn", "DISMISS_CLAIM");
     }
@@ -86,6 +87,14 @@ class ClaimDismissedTest extends BpmnBaseTest {
             PROCESS_CASE_EVENT,
             "NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_DISMISSED",
             "ClaimDismissedNotifyApplicantSolicitor1"
+        );
+
+        //Notify RPA - Handed Offline
+        ExternalTask notifyRpaHandedOffline = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(notifyRpaHandedOffline,
+                                   PROCESS_CASE_EVENT,
+                                   NOTIFY_RPA_ON_CASE_HANDED_OFFLINE,
+                                   NOTIFY_RPA_ON_CASE_HANDED_OFFLINE_ACTIVITY_ID
         );
 
         //end business process


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CIV-4632
Moving the notify RPA event just after notifying applicant solicitor 1 to send an email to RPA when a claim is dismissed .

![image](https://user-images.githubusercontent.com/91558674/188196883-d5b25ebe-53be-4d9c-9404-26aff92c4058.png)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
