### PR TITLE
adding stale config for stale pr

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -32,5 +32,5 @@ jobs:
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
           days-before-close: '0'
-          days-before-stale: '7'
+          days-before-stale: '5'
           exempt-pr-labels: 'pinned'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-    - cron: '30 3 * * *'
+    - cron: '0 3 * * *'
 
 jobs:
   stale:
@@ -31,6 +31,6 @@ jobs:
             for your contributions.
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
-          days-before-close: '4'
+          days-before-close: '0'
           days-before-stale: '7'
-          exempt-pr-labels: 'pinned,dependencies'
+          exempt-pr-labels: 'pinned'


### PR DESCRIPTION
### Change description ###
Added a github flow for stale PRs which will mark PRs as stale after 7 days of inactivity and close them


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
