### PR TITLE
Feat/civ 4480 - Move to decision outcome

### DIFF
--- a/src/main/resources/camunda/decision_outcome_scheduler.bpmn
+++ b/src/main/resources/camunda/decision_outcome_scheduler.bpmn
@@ -3,7 +3,7 @@
   <bpmn:process id="DECISION_OUTCOME_SCHEDULER" isExecutable="true">
     <bpmn:sequenceFlow id="Flow_03at47ue" sourceRef="StartEvent_1" targetRef="decisionOutcomeScheduler" />
     <bpmn:sequenceFlow id="Flow_9lwi8op" sourceRef="decisionOutcomeScheduler" targetRef="Event_1ifnnom" />
-    <bpmn:serviceTask id="decisionOutcomeScheduler" name="Decision outcome scheduler" camunda:type="external" camunda:topic="DECISION_OUTCOME">
+    <bpmn:serviceTask id="decisionOutcomeScheduler" name="Decision outcome scheduler" camunda:type="external" camunda:topic="MOVE_TO_DECISION_OUTCOME">
       <bpmn:incoming>Flow_03at47ue</bpmn:incoming>
       <bpmn:outgoing>Flow_9lwi8op</bpmn:outgoing>
     </bpmn:serviceTask>

--- a/src/main/resources/camunda/decision_outcome_scheduler.bpmn
+++ b/src/main/resources/camunda/decision_outcome_scheduler.bpmn
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_02cs6jr" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.1.0">
+  <bpmn:process id="DECISION_OUTCOME_SCHEDULER" isExecutable="true">
+    <bpmn:sequenceFlow id="Flow_03at47ue" sourceRef="StartEvent_1" targetRef="decisionOutcomeScheduler" />
+    <bpmn:sequenceFlow id="Flow_9lwi8op" sourceRef="decisionOutcomeScheduler" targetRef="Event_1ifnnom" />
+    <bpmn:serviceTask id="decisionOutcomeScheduler" name="Decision outcome scheduler" camunda:type="external" camunda:topic="DECISION_OUTCOME">
+      <bpmn:incoming>Flow_03at47ue</bpmn:incoming>
+      <bpmn:outgoing>Flow_9lwi8op</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_03at47ue</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1oppfcm">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 1 0 * * ?</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_1ifnnom">
+      <bpmn:incoming>Flow_9lwi8op</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="DECISION_OUTCOME_SCHEDULER">
+      <bpmndi:BPMNEdge id="Flow_1m5i8op_di" bpmnElement="Flow_9lwi8op">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_03at42s_di" bpmnElement="Flow_03at47ue">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_1qred84_di" bpmnElement="decisionOutcomeScheduler">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0lbh5uj_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_034z4bv_di" bpmnElement="Event_1ifnnom">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/DecisionOutcomeSchedulerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/DecisionOutcomeSchedulerTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class DecisionOutcomeSchedulerTest extends BpmnBaseTest {
 
-    public static final String TOPIC_NAME = "DECISION_OUTCOME";
+    public static final String TOPIC_NAME = "MOVE_TO_DECISION_OUTCOME";
 
     public DecisionOutcomeSchedulerTest() {
         super("decision_outcome_scheduler.bpmn", "DECISION_OUTCOME_SCHEDULER");

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/DecisionOutcomeSchedulerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/DecisionOutcomeSchedulerTest.java
@@ -1,0 +1,64 @@
+package uk.gov.hmcts.reform.civil.bpmn;
+
+import org.camunda.bpm.engine.externaltask.ExternalTask;
+import org.camunda.bpm.engine.externaltask.LockedExternalTask;
+import org.camunda.bpm.engine.impl.calendar.CronExpression;
+import org.camunda.bpm.engine.management.JobDefinition;
+import org.junit.jupiter.api.Test;
+
+import java.text.ParseException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class DecisionOutcomeSchedulerTest extends BpmnBaseTest {
+
+    public static final String TOPIC_NAME = "DECISION_OUTCOME";
+
+    public DecisionOutcomeSchedulerTest() {
+        super("decision_outcome_scheduler.bpmn", "DECISION_OUTCOME_SCHEDULER");
+    }
+
+    @Test
+    void schedulerShouldRaiseDecisionOutcomeExternalTask_whenStarted() throws ParseException {
+        //assert process has started
+        assertFalse(processInstance.isEnded());
+
+        //assert topic names
+        assertThat(getTopics()).containsOnly(TOPIC_NAME);
+
+        //get jobs
+        List<JobDefinition> jobDefinitions = getJobs();
+
+        //assert that job is as expected
+        assertThat(jobDefinitions).hasSize(1);
+        assertThat(jobDefinitions.get(0).getJobType()).isEqualTo("timer-start-event");
+
+        String cronString = "0 1 0 * * ?";
+        assertThat(jobDefinitions.get(0).getJobConfiguration()).isEqualTo("CYCLE: " + cronString);
+        assertCronTriggerFiresAtExpectedTime(
+            new CronExpression(cronString),
+            LocalDateTime.of(2020, 1, 1, 0, 0, 0),
+            LocalDateTime.of(2020, 1, 1, 0, 1, 0)
+        );
+
+        //get external tasks
+        List<ExternalTask> externalTasks = getExternalTasks();
+        assertThat(externalTasks).hasSize(1);
+
+        //fetch and complete task
+        List<LockedExternalTask> lockedExternalTasks = fetchAndLockTask(TOPIC_NAME);
+
+        assertThat(lockedExternalTasks).hasSize(1);
+        completeTask(lockedExternalTasks.get(0).getId());
+
+        //assert no external tasks left
+        List<ExternalTask> externalTasksAfter = getExternalTasks();
+        assertThat(externalTasksAfter).isEmpty();
+
+        //assert process is still active - timer event, so always running
+        assertFalse(processInstance.isEnded());
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-4480

### Change description ###
Camunda scheduler to trigger a check for decision outcomes
![image](https://user-images.githubusercontent.com/107135537/196733028-16acfc59-da42-4370-9a06-eb70a23c2dc7.png)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
