### PR TITLE
CIV-4838: Fix for CVE-2022-24329

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,24 @@ allprojects {
       ) {
         entry 'camunda-engine'
       }
+      dependencySet(
+        group: 'org.jetbrains.kotlin',
+        version: '1.7.0'
+      ) {
+        entry 'kotlin-stdlib-common'
+      }
+      dependencySet(
+        group: 'org.jetbrains.kotlin',
+        version: '1.7.10'
+      ) {
+        entry 'kotlin-stdlib'
+      }
+      dependencySet(
+        group: 'org.jetbrains.kotlin',
+        version: '1.7.0'
+      ) {
+        entry 'kotlin-reflect'
+      }
     }
     imports {
       mavenBom 'org.springframework.cloud:spring-cloud-dependencies:2021.0.4'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -77,27 +77,6 @@
     <cve>CVE-2020-36518</cve>
   </suppress>
   <suppress>
-    <notes><![CDATA[
-   file name: kotlin-reflect-1.5.20.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-reflect@.*$</packageUrl>
-    <cve>CVE-2022-24329</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: kotlin-stdlib-1.5.20.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-stdlib@.*$</packageUrl>
-    <cve>CVE-2022-24329</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: kotlin-stdlib-common-1.5.20.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin\-stdlib\-common@.*$</packageUrl>
-    <cve>CVE-2022-24329</cve>
-  </suppress>
-  <suppress>
     <cve>CVE-2022-22965</cve>
   </suppress>
   <suppress>


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-4838

### Change description ###

In JetBrains Kotlin before 1.6.0, it was not possible to lock dependencies for Multiplatform Gradle Projects.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
