### PR TITLE
CIV-5093 created a new scheduler for GA Order Made end date

### DIFF
--- a/src/main/resources/camunda/general_application_order_made_scheduler.bpmn
+++ b/src/main/resources/camunda/general_application_order_made_scheduler.bpmn
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_14qf5vi" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0">
+  <bpmn:process id="GA_ORDER_MADE_SCHEDULER" name="GA OrderMade Scheduler" isExecutable="true">
+    <bpmn:serviceTask id="GAOrderMadeSchedulerActivityId" name="GA OrderMade Scheduler" camunda:type="external" camunda:topic="GAOrderMadeScheduler">
+      <bpmn:extensionElements />
+      <bpmn:incoming>Flow_1gnbmqe</bpmn:incoming>
+      <bpmn:outgoing>Flow_0tjw87e</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_0dr3fkw">
+      <bpmn:incoming>Flow_0tjw87e</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1gnbmqe" sourceRef="GAFetchCasesWithOrderMadeTimer" targetRef="GAOrderMadeSchedulerActivityId" />
+    <bpmn:sequenceFlow id="Flow_0tjw87e" sourceRef="GAOrderMadeSchedulerActivityId" targetRef="Event_0dr3fkw" />
+    <bpmn:startEvent id="GAFetchCasesWithOrderMadeTimer">
+      <bpmn:outgoing>Flow_1gnbmqe</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_0g5qu8x">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 15 16 ? * * *</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="GA_ORDER_MADE_SCHEDULER">
+      <bpmndi:BPMNEdge id="Flow_0tjw87e_di" bpmnElement="Flow_0tjw87e">
+        <di:waypoint x="390" y="120" />
+        <di:waypoint x="492" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gnbmqe_di" bpmnElement="Flow_1gnbmqe">
+        <di:waypoint x="235" y="120" />
+        <di:waypoint x="290" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_1ydkywr_di" bpmnElement="GAOrderMadeSchedulerActivityId">
+        <dc:Bounds x="290" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0okg972_di" bpmnElement="GAFetchCasesWithOrderMadeTimer">
+        <dc:Bounds x="199" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0dr3fkw_di" bpmnElement="Event_0dr3fkw">
+        <dc:Bounds x="492" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x ] commit messages are meaningful and follow good commit message guidelines
- [ x] README and other documentation has been updated / added (if needed)
- [ x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-5093

### Change description ###

Camunda changes
Created a new scheduler to check the cases where the states is ORDER_MADE and its Judge approved end date is on that day
will trigger a new event for Work Allocation only for Applications where its type contains STAY_THE_CLAIM
![image](https://user-images.githubusercontent.com/107422736/197834788-f044746c-64ff-4a39-bd23-d0ed56087bc5.png)


**Does this PR introduce a breaking change?** (check one with "x")

```
[x ] Yes
[ ] No
```
