### PR TITLE
Detection of duplicate process id in Camunda files

### DIFF
--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ProcessIdSanityCheckTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ProcessIdSanityCheckTest.java
@@ -1,0 +1,69 @@
+package uk.gov.hmcts.reform.civil.bpmn;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProcessIdSanityCheckTest {
+
+    DocumentBuilder documentBuilder;
+
+    @BeforeEach
+    void prepareDomParser() throws Exception {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        documentBuilder = dbf.newDocumentBuilder();
+    }
+
+    @Test
+    void ensureProcessIdUniqueness() throws Exception {
+        // Given: all the Camunda files
+        PathMatchingResourcePatternResolver resourcePatternResolver = new PathMatchingResourcePatternResolver();
+        Resource[] resources = resourcePatternResolver.getResources("classpath:camunda/**.bpmn");
+
+        // When: I scan them and extract the process id
+        Map<String, List<URL>> processIds = new HashMap<>();
+        for (Resource resource : resources) {
+            String processId = extractProcessId(resource);
+            List<URL> urls = processIds.computeIfAbsent(processId, k -> new ArrayList<>());
+            urls.add(resource.getURL());
+        }
+
+        // Then: no two different files can have the same process id
+        processIds.entrySet().stream().filter(entry -> entry.getValue().size() > 1)
+                .forEach(entry -> {
+                    entry.getValue().forEach(url -> System.out.println(entry.getKey() + " --> " + url.toString()));
+                });
+        assertThat(processIds.entrySet().stream().noneMatch(entry -> entry.getValue().size() > 1))
+            .withFailMessage("Some duplicate values for <bpmn:process id> were found. This will cause"
+                                 + " failures in Camunda. Please check the affected files and make sure that none"
+                                 + " has duplicate process id values.")
+            .isTrue();
+
+
+    }
+
+
+    private String extractProcessId(Resource resource) throws Exception {
+        Document doc = documentBuilder.parse(resource.getInputStream());
+        NodeList nodes = doc.getElementsByTagName("bpmn:process");
+        Node node = nodes.item(0);
+        NamedNodeMap attributes = node.getAttributes();
+        return attributes.getNamedItem("id").getNodeValue();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ProcessIdSanityCheckTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ProcessIdSanityCheckTest.java
@@ -1,13 +1,5 @@
 package uk.gov.hmcts.reform.civil.bpmn;
 
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.Resource;
@@ -16,6 +8,14 @@ import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ProcessIdSanityCheckTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ProcessIdSanityCheckTest.java
@@ -55,7 +55,6 @@ class ProcessIdSanityCheckTest {
             .isTrue();
     }
 
-
     private String extractProcessId(Resource resource) throws Exception {
         Document doc = documentBuilder.parse(resource.getInputStream());
         NodeList nodes = doc.getElementsByTagName("bpmn:process");

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ProcessIdSanityCheckTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ProcessIdSanityCheckTest.java
@@ -1,13 +1,12 @@
 package uk.gov.hmcts.reform.civil.bpmn;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,8 +53,6 @@ class ProcessIdSanityCheckTest {
                                  + " failures in Camunda. Please check the affected files and make sure that none"
                                  + " has duplicate process id values.")
             .isTrue();
-
-
     }
 
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
CIV-6213

### Change description ###
A change recently committed resulted in Camunda builds working but then raising errors in ccd and civil-service.
The investigation from Harry Henry resulted in the issue being identified in the duplication of values for the "id" property of the <bpmn:process> tag.
This happened as the Camunda process for two files was identical except for a small detail, so the developer copied the file and made the necessary change. What the developer didn't know was that there's another property higher up in the hierarchy that Camunda uses to identify the processes and this property had the same value across the two files, resulting in Camunda interpreting the second file as a new version of the same process.

This PR adds a "sanity check" test to ensure that all the process ids are unique, thus preventing these errors from happening in the future.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
