### PR TITLE
CIV-6413: Added logic for not notifying unrepresented defendant1

### DIFF
--- a/src/main/resources/camunda/case_proceeds_in_caseman.bpmn
+++ b/src/main/resources/camunda/case_proceeds_in_caseman.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0rn46su" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0rn46su" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0">
   <bpmn:process id="CASE_PROCEEDS_IN_CASEMAN" isExecutable="true">
     <bpmn:startEvent id="Event_StartClaimTakenOffline" name="Start">
       <bpmn:outgoing>Flow_NextStartBusinessProcess</bpmn:outgoing>
@@ -40,7 +40,7 @@
           <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CASE_PROCEEDS_IN_CASEMAN</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0w2xd7v</bpmn:incoming>
+      <bpmn:incoming>Flow_1wemeph</bpmn:incoming>
       <bpmn:outgoing>Flow_1hq815y</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_1hq815y" sourceRef="CaseProceedsInCasemanNotifyRespondentSolicitor1" targetRef="CaseProceedsInCasemanNotifyApplicantSolicitor1" />
@@ -51,6 +51,7 @@
         </camunda:inputOutput>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1hq815y</bpmn:incoming>
+      <bpmn:incoming>Flow_19s461k</bpmn:incoming>
       <bpmn:outgoing>Flow_0uljtsx</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_0uljtsx" sourceRef="CaseProceedsInCasemanNotifyApplicantSolicitor1" targetRef="Activity_EndBusinessProcess" />
@@ -64,7 +65,7 @@
       <bpmn:incoming>Flow_1v2x5ki</bpmn:incoming>
       <bpmn:outgoing>Flow_0w2xd7v</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0w2xd7v" sourceRef="NotifyRoboticsOnCaseHandedOffline" targetRef="CaseProceedsInCasemanNotifyRespondentSolicitor1" />
+    <bpmn:sequenceFlow id="Flow_0w2xd7v" sourceRef="NotifyRoboticsOnCaseHandedOffline" targetRef="Gateway_0q0xiq7" />
     <bpmn:serviceTask id="ProceedOffline" name="Proceed Offline" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
@@ -106,11 +107,58 @@
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.GENERAL_APPLICATION_ENABLED &amp;&amp; flowFlags.GENERAL_APPLICATION_ENABLED}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_1v2x5ki" sourceRef="UpdateClaimWithApplicationStatus" targetRef="NotifyRoboticsOnCaseHandedOffline" />
+    <bpmn:exclusiveGateway id="Gateway_0q0xiq7">
+      <bpmn:incoming>Flow_0w2xd7v</bpmn:incoming>
+      <bpmn:outgoing>Flow_1wemeph</bpmn:outgoing>
+      <bpmn:outgoing>Flow_19s461k</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1wemeph" name="Defendant 1 is represented" sourceRef="Gateway_0q0xiq7" targetRef="CaseProceedsInCasemanNotifyRespondentSolicitor1">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${empty flowFlags.UNREPRESENTED_DEFENDANT_ONE  || (!empty flowFlags.UNREPRESENTED_DEFENDANT_ONE &amp;&amp; !flowFlags.UNREPRESENTED_DEFENDANT_ONE)}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_19s461k" name="Defendant 1 is unrepresented" sourceRef="Gateway_0q0xiq7" targetRef="CaseProceedsInCasemanNotifyApplicantSolicitor1">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.UNREPRESENTED_DEFENDANT_ONE &amp;&amp; flowFlags.UNREPRESENTED_DEFENDANT_ONE}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
   </bpmn:process>
   <bpmn:message id="Message_0slk3de" name="CASE_PROCEEDS_IN_CASEMAN" />
   <bpmn:error id="Error_0t2ju7k" name="StartBusinessAbort" errorCode="ABORT" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="CASE_PROCEEDS_IN_CASEMAN">
+      <bpmndi:BPMNEdge id="Flow_1v2x5ki_di" bpmnElement="Flow_1v2x5ki">
+        <di:waypoint x="833" y="330" />
+        <di:waypoint x="873" y="330" />
+        <di:waypoint x="873" y="210" />
+        <di:waypoint x="912" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1f54woo_di" bpmnElement="Flow_1f54woo">
+        <di:waypoint x="547" y="235" />
+        <di:waypoint x="547" y="330" />
+        <di:waypoint x="589" y="330" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0pl9ize_di" bpmnElement="Flow_0pl9ize">
+        <di:waypoint x="689" y="330" />
+        <di:waypoint x="733" y="330" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_12q4mv0_di" bpmnElement="Flow_12q4mv0">
+        <di:waypoint x="572" y="210" />
+        <di:waypoint x="912" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10rsj5g_di" bpmnElement="Flow_10rsj5g">
+        <di:waypoint x="470" y="210" />
+        <di:waypoint x="522" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0w2xd7v_di" bpmnElement="Flow_0w2xd7v">
+        <di:waypoint x="1012" y="210" />
+        <di:waypoint x="1045" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uljtsx_di" bpmnElement="Flow_0uljtsx">
+        <di:waypoint x="1360" y="210" />
+        <di:waypoint x="1420" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hq815y_di" bpmnElement="Flow_1hq815y">
+        <di:waypoint x="1190" y="130" />
+        <di:waypoint x="1190" y="210" />
+        <di:waypoint x="1260" y="210" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_14aod2o_di" bpmnElement="Flow_NextNotifyRpa">
         <di:waypoint x="330" y="210" />
         <di:waypoint x="370" y="210" />
@@ -124,43 +172,23 @@
         <di:waypoint x="280" y="118" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1hce35l_di" bpmnElement="Flow_NextEndEvent">
-        <di:waypoint x="1462" y="210" />
-        <di:waypoint x="1534" y="210" />
+        <di:waypoint x="1520" y="210" />
+        <di:waypoint x="1582" y="210" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0uljtsx_di" bpmnElement="Flow_0uljtsx">
-        <di:waypoint x="1312" y="210" />
-        <di:waypoint x="1362" y="210" />
+      <bpmndi:BPMNEdge id="Flow_1wemeph_di" bpmnElement="Flow_1wemeph">
+        <di:waypoint x="1070" y="185" />
+        <di:waypoint x="1070" y="90" />
+        <di:waypoint x="1140" y="90" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1064" y="56" width="72" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0w2xd7v_di" bpmnElement="Flow_0w2xd7v">
-        <di:waypoint x="1012" y="210" />
-        <di:waypoint x="1072" y="210" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1hq815y_di" bpmnElement="Flow_1hq815y">
-        <di:waypoint x="1172" y="210" />
-        <di:waypoint x="1212" y="210" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_10rsj5g_di" bpmnElement="Flow_10rsj5g">
-        <di:waypoint x="470" y="210" />
-        <di:waypoint x="522" y="210" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_12q4mv0_di" bpmnElement="Flow_12q4mv0">
-        <di:waypoint x="572" y="210" />
-        <di:waypoint x="912" y="210" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1f54woo_di" bpmnElement="Flow_1f54woo">
-        <di:waypoint x="547" y="235" />
-        <di:waypoint x="547" y="330" />
-        <di:waypoint x="589" y="330" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0pl9ize_di" bpmnElement="Flow_0pl9ize">
-        <di:waypoint x="689" y="330" />
-        <di:waypoint x="733" y="330" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1v2x5ki_di" bpmnElement="Flow_1v2x5ki">
-        <di:waypoint x="833" y="330" />
-        <di:waypoint x="873" y="330" />
-        <di:waypoint x="873" y="210" />
-        <di:waypoint x="912" y="210" />
+      <bpmndi:BPMNEdge id="Flow_19s461k_di" bpmnElement="Flow_19s461k">
+        <di:waypoint x="1095" y="210" />
+        <di:waypoint x="1260" y="210" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1104" y="176" width="72" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1m02c2o_di" bpmnElement="Event_StartClaimTakenOffline">
         <dc:Bounds x="152" y="192" width="36" height="36" />
@@ -174,23 +202,11 @@
       <bpmndi:BPMNShape id="Event_1nsmt51_di" bpmnElement="Event_1nsmt51">
         <dc:Bounds x="262" y="82" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_05vy1ua_di" bpmnElement="ProceedOffline">
-        <dc:Bounds x="370" y="170" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0r8yo0r_di" bpmnElement="Event_EndClaimTakenOffline">
-        <dc:Bounds x="1534" y="192" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1x5rl4x_di" bpmnElement="Activity_EndBusinessProcess">
-        <dc:Bounds x="1362" y="170" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0lrzkzm_di" bpmnElement="CaseProceedsInCasemanNotifyRespondentSolicitor1">
-        <dc:Bounds x="1072" y="170" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1huplho_di" bpmnElement="CaseProceedsInCasemanNotifyApplicantSolicitor1">
-        <dc:Bounds x="1212" y="170" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1kdqyo6_di" bpmnElement="NotifyRoboticsOnCaseHandedOffline">
         <dc:Bounds x="912" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_05vy1ua_di" bpmnElement="ProceedOffline">
+        <dc:Bounds x="370" y="170" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1t3w36j_di" bpmnElement="Gateway_1t3w36j" isMarkerVisible="true">
         <dc:Bounds x="522" y="185" width="50" height="50" />
@@ -200,6 +216,21 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_11e80kd_di" bpmnElement="UpdateClaimWithApplicationStatus">
         <dc:Bounds x="733" y="290" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0r8yo0r_di" bpmnElement="Event_EndClaimTakenOffline">
+        <dc:Bounds x="1582" y="192" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1x5rl4x_di" bpmnElement="Activity_EndBusinessProcess">
+        <dc:Bounds x="1420" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1huplho_di" bpmnElement="CaseProceedsInCasemanNotifyApplicantSolicitor1">
+        <dc:Bounds x="1260" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0q0xiq7_di" bpmnElement="Gateway_0q0xiq7" isMarkerVisible="true">
+        <dc:Bounds x="1045" y="185" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0lrzkzm_di" bpmnElement="CaseProceedsInCasemanNotifyRespondentSolicitor1">
+        <dc:Bounds x="1140" y="50" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1fn0bf1_di" bpmnElement="Event_1fn0bf1">
         <dc:Bounds x="262" y="152" width="36" height="36" />

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/CaseProceedsInCasemanTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/CaseProceedsInCasemanTest.java
@@ -4,6 +4,8 @@ import org.camunda.bpm.engine.externaltask.ExternalTask;
 import org.camunda.bpm.engine.variable.VariableMap;
 import org.camunda.bpm.engine.variable.Variables;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.util.Map;
 
@@ -167,6 +169,73 @@ class CaseProceedsInCasemanTest extends BpmnBaseTest {
         assertNoExternalTasksLeft();
     }
 
+    @ParameterizedTest
+    @CsvSource({"true", "false", "null"})
+    void shouldSuccessfullyComplete_unrepresentedDefendant(boolean unrepresentedDefendant1) {
+        //assert process has started
+        assertFalse(processInstance.isEnded());
+
+        //assert message start event
+        assertThat(getProcessDefinitionByMessage(MESSAGE_NAME).getKey()).isEqualTo(PROCESS_ID);
+
+        VariableMap variables = Variables.createVariables();
+        variables.put("flowFlags", Map.of(
+            UNREPRESENTED_DEFENDANT_ONE, unrepresentedDefendant1,
+            GENERAL_APPLICATION_ENABLED, false
+        ));
+
+        //complete the start business process
+        ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
+        assertCompleteExternalTask(
+            startBusiness,
+            START_BUSINESS_TOPIC,
+            START_BUSINESS_EVENT,
+            START_BUSINESS_ACTIVITY,
+            variables
+        );
+
+        //Take offline
+        ExternalTask takeOffline = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            takeOffline,
+            PROCESS_CASE_EVENT,
+            PROCEEDS_IN_HERITAGE_SYSTEM_EVENT,
+            PROCEEDS_IN_HERITAGE_SYSTEM_ACTIVITY_ID
+        );
+
+        //complete the RPA notification
+        ExternalTask rpaNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            rpaNotification,
+            PROCESS_CASE_EVENT,
+            "NOTIFY_RPA_ON_CASE_HANDED_OFFLINE",
+            "NotifyRoboticsOnCaseHandedOffline"
+        );
+
+        //complete the notification to respondent 1
+        if (!unrepresentedDefendant1) {
+            ExternalTask respondentNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
+            assertCompleteExternalTask(respondentNotification,
+                                       PROCESS_CASE_EVENT,
+                                       "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CASE_PROCEEDS_IN_CASEMAN",
+                                       "CaseProceedsInCasemanNotifyRespondentSolicitor1"
+            );
+        }
+
+        //complete the notification to applicant
+        ExternalTask applicantNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(applicantNotification,
+                                   PROCESS_CASE_EVENT,
+                                   "NOTIFY_APPLICANT_SOLICITOR1_FOR_CASE_PROCEEDS_IN_CASEMAN",
+                                   "CaseProceedsInCasemanNotifyApplicantSolicitor1"
+        );
+
+        //end business process
+        ExternalTask endBusinessProcess = assertNextExternalTask(END_BUSINESS_PROCESS);
+        completeBusinessProcess(endBusinessProcess);
+
+        assertNoExternalTasksLeft();
+    }
     @Test
     void shouldAbort_whenStartBusinessProcessThrowsAnError() {
         //assert process has started

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/CaseProceedsInCasemanTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/CaseProceedsInCasemanTest.java
@@ -236,6 +236,7 @@ class CaseProceedsInCasemanTest extends BpmnBaseTest {
 
         assertNoExternalTasksLeft();
     }
+
     @Test
     void shouldAbort_whenStartBusinessProcessThrowsAnError() {
         //assert process has started


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-6413


### Change description ###

Modified case_proceeds_in_caseman and added logic for not informing unrepresented defendant1. Two new conditions added for logic

![image](https://user-images.githubusercontent.com/106387766/207085048-4de29286-beb9-45ca-b11c-074ea55fb1fb.png)

Added following conditions to bpm

- For informing represented defendandt : 
  ${empty flowFlags.UNREPRESENTED_DEFENDANT_ONE  || (!empty flowFlags.UNREPRESENTED_DEFENDANT_ONE && !flowFlags.UNREPRESENTED_DEFENDANT_ONE)}

- For continue flow without informing defendant1: 
    ${!empty flowFlags.UNREPRESENTED_DEFENDANT_ONE && flowFlags.UNREPRESENTED_DEFENDANT_ONE}

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
