### PR TITLE
CIV-6644 Clear pods always and enableHelm

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -2,6 +2,7 @@
 
 @Library("Infrastructure")
 import uk.gov.hmcts.contino.AppPipelineConfig
+import uk.gov.hmcts.contino.GithubAPI
 
 def type = "java"
 def product = "civil"
@@ -58,6 +59,10 @@ def uploadBpmnDiagrams(String env) {
   }
 }
 
+def checkForEnableHelmLabel(branch_name) {
+  return new GithubAPI(this).getLabelsbyPattern(branch_name, "enableHelm").contains("enableHelm")
+}
+
 withPipeline(type, product, component) {
   pipelineConf = config
   disableLegacyDeployment()
@@ -67,7 +72,9 @@ withPipeline(type, product, component) {
   onPR {
     env.ENVIRONMENT = "preview"
     loadVaultSecrets(secrets)
-    enableCleanupOfHelmReleaseOnSuccess()
+    if (!checkForEnableHelmLabel(env.BRANCH_NAME)) {
+      enableCleanupOfHelmReleaseAlways();
+    }
     env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
   }
   onMaster {


### PR DESCRIPTION
### JIRA link (if applicable) ###
CIV-6644


### Change description ###
- Always clears the pods regardless of success or failure
- Bonus: Observes "enableHelm" label to prevent deletion of pods on success if so desired



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
