### PR TITLE
CIV-6479 - added default flow to camunda

### DIFF
--- a/src/main/resources/camunda/breathing_space_lifted.bpmn
+++ b/src/main/resources/camunda/breathing_space_lifted.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1iivus5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1iivus5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
   <bpmn:process id="BREATHING_SPACE_LIFTED" isExecutable="true">
     <bpmn:startEvent id="Event_0y09tpb" name="Start">
       <bpmn:outgoing>Flow_07qelqa</bpmn:outgoing>
@@ -42,7 +42,7 @@
       <bpmn:outgoing>Flow_1nx22hv</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_0lzk3lu" sourceRef="NotifyApplicantSolicitorBSLifted" targetRef="NotifyRespondentSolicitorBSLifted" />
-    <bpmn:exclusiveGateway id="RPA_Continuous_Feed_Gate">
+    <bpmn:exclusiveGateway id="RPA_Continuous_Feed_Gate" default="Flow_1c2ryxi">
       <bpmn:incoming>Flow_1nx22hv</bpmn:incoming>
       <bpmn:outgoing>Flow_RPA_CONTINUOUS_FEED</bpmn:outgoing>
       <bpmn:outgoing>Flow_1c2ryxi</bpmn:outgoing>

--- a/src/main/resources/camunda/inform_agreed_extension_date.bpmn
+++ b/src/main/resources/camunda/inform_agreed_extension_date.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_0d4bcaj" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_0d4bcaj" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0">
   <bpmn:process id="INFORM_AGREED_EXTENSION_DATE_PROCESS_ID" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Start">
       <bpmn:outgoing>Flow_0cbpb7a</bpmn:outgoing>
@@ -79,7 +79,7 @@
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.RPA_CONTINUOUS_FEED &amp;&amp; !flowFlags.RPA_CONTINUOUS_FEED}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_1ndy0k7" sourceRef="Activity_1i1bcz2" targetRef="Event_1520zkg" />
-    <bpmn:exclusiveGateway id="Gateway_Two_Representative">
+    <bpmn:exclusiveGateway id="Gateway_Two_Representative" default="Flow_1tozk0l">
       <bpmn:incoming>Flow_0f0tmte</bpmn:incoming>
       <bpmn:outgoing>Flow_1awd2ov</bpmn:outgoing>
       <bpmn:outgoing>Flow_1tozk0l</bpmn:outgoing>
@@ -103,6 +103,50 @@
   <bpmn:message id="Message_1b64xfv" name="INFORM_AGREED_EXTENSION_DATE" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="INFORM_AGREED_EXTENSION_DATE_PROCESS_ID">
+      <bpmndi:BPMNEdge id="Flow_00d846q_di" bpmnElement="Flow_00d846q">
+        <di:waypoint x="850" y="160" />
+        <di:waypoint x="850" y="287" />
+        <di:waypoint x="905" y="287" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1tozk0l_di" bpmnElement="Flow_1tozk0l">
+        <di:waypoint x="795" y="287" />
+        <di:waypoint x="905" y="287" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1wja5sy_di" bpmnElement="Flow_0f0tmte">
+        <di:waypoint x="630" y="287" />
+        <di:waypoint x="745" y="287" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1awd2ov_di" bpmnElement="Flow_1awd2ov">
+        <di:waypoint x="770" y="262" />
+        <di:waypoint x="770" y="120" />
+        <di:waypoint x="800" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="688" y="180" width="84" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ndy0k7_di" bpmnElement="Flow_1ndy0k7">
+        <di:waypoint x="1210" y="287" />
+        <di:waypoint x="1252" y="287" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08aucbc_di" bpmnElement="Flow_RPA_NO_CONTINUOUS_FEED">
+        <di:waypoint x="955" y="287" />
+        <di:waypoint x="1110" y="287" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="996" y="256" width="73" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0xb34x1_di" bpmnElement="Flow_RPA_Continuous_Feed_Completed">
+        <di:waypoint x="980" y="470" />
+        <di:waypoint x="1170" y="470" />
+        <di:waypoint x="1170" y="327" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0jdqa5z_di" bpmnElement="Flow_RPA_CONTINUOUS_FEED">
+        <di:waypoint x="930" y="312" />
+        <di:waypoint x="930" y="430" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="939" y="326" width="81" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_18b51mb_di" bpmnElement="Flow_18b51mb">
         <di:waypoint x="500" y="287" />
         <di:waypoint x="530" y="287" />
@@ -119,50 +163,6 @@
         <di:waypoint x="320" y="229" />
         <di:waypoint x="320" y="195" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0xb34x1_di" bpmnElement="Flow_RPA_Continuous_Feed_Completed">
-        <di:waypoint x="980" y="470" />
-        <di:waypoint x="1170" y="470" />
-        <di:waypoint x="1170" y="327" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_08aucbc_di" bpmnElement="Flow_RPA_NO_CONTINUOUS_FEED">
-        <di:waypoint x="955" y="287" />
-        <di:waypoint x="1110" y="287" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="996" y="256" width="73" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1ndy0k7_di" bpmnElement="Flow_1ndy0k7">
-        <di:waypoint x="1210" y="287" />
-        <di:waypoint x="1252" y="287" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0jdqa5z_di" bpmnElement="Flow_RPA_CONTINUOUS_FEED">
-        <di:waypoint x="930" y="312" />
-        <di:waypoint x="930" y="430" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="939" y="326" width="81" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1awd2ov_di" bpmnElement="Flow_1awd2ov">
-        <di:waypoint x="770" y="262" />
-        <di:waypoint x="770" y="120" />
-        <di:waypoint x="800" y="120" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="688" y="180" width="84" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1wja5sy_di" bpmnElement="Flow_0f0tmte">
-        <di:waypoint x="630" y="287" />
-        <di:waypoint x="745" y="287" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1tozk0l_di" bpmnElement="Flow_1tozk0l">
-        <di:waypoint x="795" y="287" />
-        <di:waypoint x="905" y="287" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_00d846q_di" bpmnElement="Flow_00d846q">
-        <di:waypoint x="850" y="160" />
-        <di:waypoint x="850" y="287" />
-        <di:waypoint x="905" y="287" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_0m7mqgu_di" bpmnElement="StartEvent_1">
         <dc:Bounds x="192" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -178,14 +178,14 @@
       <bpmndi:BPMNShape id="Activity_0cx0xe8_di" bpmnElement="AgreedExtensionDateNotifyApplicantSolicitor1">
         <dc:Bounds x="400" y="247" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0jtsmci_di" bpmnElement="AgreedExtensionDateNotifyRespondentSolicitor1CC">
-        <dc:Bounds x="530" y="247" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1i1bcz2_di" bpmnElement="Activity_1i1bcz2">
         <dc:Bounds x="1110" y="247" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1520zkg_di" bpmnElement="Event_1520zkg">
         <dc:Bounds x="1252" y="269" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0jtsmci_di" bpmnElement="AgreedExtensionDateNotifyRespondentSolicitor1CC">
+        <dc:Bounds x="530" y="247" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1b8pri3_di" bpmnElement="Gateway_RPA_CONTINUOUS_FEED" isMarkerVisible="true">
         <dc:Bounds x="905" y="262" width="50" height="50" />


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-6479


### Change description ###
added default flow to camunda where no default was present to resolve warning in logs.

## Log error message
```
Exclusive Gateway 'RPA_Continuous_Feed_Gate' has outgoing sequence flow 'FLOW_WITHOUT_DEFAULT' without condition which is not the default flow. We assume it to be the default flow, but it is bad modeling practice, better set the default flow in your gateway. | resource FILE_WARNING_PRESENT_IN
```
the files warning present in changed in this PR is: `inform_agreed_extension_date.bpmn` and `breathing_space_lifted.bpmn`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
