### PR TITLE
CIV-7931 Docmosis Output when Consent Order Approved

### DIFF
--- a/src/main/resources/camunda/caseworker_makes_decision_general_application.bpmn
+++ b/src/main/resources/camunda/caseworker_makes_decision_general_application.bpmn
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0yyqken" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.5.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:collaboration id="CaseworkerMakesDecision">
+    <bpmn:participant id="Participant_12pdlbz" name="CaseWorker Makes Decision" processRef="APPROVE_CONSENT_ORDER_PROCESS_ID" />
+  </bpmn:collaboration>
+  <bpmn:process id="APPROVE_CONSENT_ORDER_PROCESS_ID" isExecutable="true">
+    <bpmn:startEvent id="Event_0gkb2ak" name="Start">
+      <bpmn:outgoing>Flow_07x5h8x</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1wt5eg9" messageRef="Message_1lvd10f" />
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_050n3oz">
+      <bpmn:incoming>Flow_1eynbb2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="GenerateConsentOrderDocument" name="Generate Consent Order Document" camunda:type="external" camunda:topic="applicationProcessCaseEventGASpec">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">GENERATE_JUDGES_FORM</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0u1jpxv</bpmn:incoming>
+      <bpmn:outgoing>Flow_1wbo8pc</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:callActivity id="Activity_088pa0l" name="Start Business Process" calledElement="StartGeneralApplicationBusinessProcessGAspec">
+      <bpmn:extensionElements>
+        <camunda:in variables="all" />
+        <camunda:out variables="all" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_07x5h8x</bpmn:incoming>
+      <bpmn:outgoing>Flow_1eynbb2</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0u1jpxv</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:serviceTask id="AddDocumentToParentCase" name="Add PDF Document To Main Case" camunda:type="external" camunda:topic="updateFromGACaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">ADD_PDF_TO_MAIN_CASE</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1wbo8pc</bpmn:incoming>
+      <bpmn:outgoing>Flow_1yg2hgc</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_1784mp1">
+      <bpmn:incoming>Flow_05s82ab</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="NotifyConsentOrderClaimant" name="Notify Consent Order Claimant" camunda:type="external" camunda:topic="processExternalCaseEventGASpec">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">START_APPLICANT_NOTIFICATION_PROCESS_MAKE_DECISION</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1yg2hgc</bpmn:incoming>
+      <bpmn:outgoing>Flow_05pbieq</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:callActivity id="Activity_0tsa73p" name="End Business Process" calledElement="EndJudgeMakesDecisionBusinessProcess">
+      <bpmn:extensionElements>
+        <camunda:in variables="all" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_16if7wo</bpmn:incoming>
+      <bpmn:outgoing>Flow_05s82ab</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:serviceTask id="NotifyConsentOrderDefendant" name="Notify Consent Order Defendant(s)" camunda:type="external" camunda:topic="processExternalCaseEventGASpec">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">START_RESPONDENT_NOTIFICATION_PROCESS_MAKE_DECISION</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_05pbieq</bpmn:incoming>
+      <bpmn:outgoing>Flow_16if7wo</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:boundaryEvent id="Event_0v0zg33" name="Abort" attachedToRef="Activity_088pa0l">
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_1ly8qz3" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_07x5h8x" sourceRef="Event_0gkb2ak" targetRef="Activity_088pa0l" />
+    <bpmn:sequenceFlow id="Flow_1eynbb2" sourceRef="Activity_088pa0l" targetRef="Event_050n3oz" />
+    <bpmn:sequenceFlow id="Flow_0u1jpxv" sourceRef="Activity_088pa0l" targetRef="GenerateConsentOrderDocument" />
+    <bpmn:sequenceFlow id="Flow_1wbo8pc" sourceRef="GenerateConsentOrderDocument" targetRef="AddDocumentToParentCase" />
+    <bpmn:sequenceFlow id="Flow_1yg2hgc" sourceRef="AddDocumentToParentCase" targetRef="NotifyConsentOrderClaimant" />
+    <bpmn:sequenceFlow id="Flow_05s82ab" sourceRef="Activity_0tsa73p" targetRef="Event_1784mp1" />
+    <bpmn:sequenceFlow id="Flow_05pbieq" sourceRef="NotifyConsentOrderClaimant" targetRef="NotifyConsentOrderDefendant" />
+    <bpmn:sequenceFlow id="Flow_16if7wo" sourceRef="NotifyConsentOrderDefendant" targetRef="Activity_0tsa73p" />
+  </bpmn:process>
+  <bpmn:message id="Message_1lvd10f" name="APPROVE_CONSENT_ORDER" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="CaseworkerMakesDecision">
+      <bpmndi:BPMNShape id="BPMNShape_15kkm7v" bpmnElement="Participant_12pdlbz" isHorizontal="true">
+        <dc:Bounds x="160" y="110" width="1320" height="400" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0chxikd" bpmnElement="Event_0gkb2ak">
+        <dc:Bounds x="231" y="260" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="237" y="303" width="25" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1kbk53p" bpmnElement="Event_050n3oz">
+        <dc:Bounds x="341" y="130" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0nur7t1_di" bpmnElement="GenerateConsentOrderDocument">
+        <dc:Bounds x="490" y="238" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_08opg4j" bpmnElement="Activity_088pa0l">
+        <dc:Bounds x="309" y="238" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1iluc48_di" bpmnElement="AddDocumentToParentCase">
+        <dc:Bounds x="670" y="238" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0gi8079" bpmnElement="Event_1784mp1">
+        <dc:Bounds x="1272" y="260" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_040qojw" bpmnElement="NotifyConsentOrderClaimant">
+        <dc:Bounds x="810" y="238" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1ooaf83" bpmnElement="Activity_0tsa73p">
+        <dc:Bounds x="1100" y="238" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1300hq4" bpmnElement="NotifyConsentOrderDefendant">
+        <dc:Bounds x="955" y="238" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_08egvj5" bpmnElement="Event_0v0zg33">
+        <dc:Bounds x="341" y="220" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="366" y="190" width="27" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_09ssg72" bpmnElement="Flow_07x5h8x">
+        <di:waypoint x="267" y="278" />
+        <di:waypoint x="309" y="278" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_04ut7zo" bpmnElement="Flow_1eynbb2">
+        <di:waypoint x="359" y="238" />
+        <di:waypoint x="359" y="166" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_0c5c1ev" bpmnElement="Flow_0u1jpxv">
+        <di:waypoint x="409" y="278" />
+        <di:waypoint x="490" y="278" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1wbo8pc_di" bpmnElement="Flow_1wbo8pc">
+        <di:waypoint x="590" y="278" />
+        <di:waypoint x="670" y="278" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1yg2hgc_di" bpmnElement="Flow_1yg2hgc">
+        <di:waypoint x="770" y="278" />
+        <di:waypoint x="810" y="278" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_05hfi5w" bpmnElement="Flow_05s82ab">
+        <di:waypoint x="1200" y="278" />
+        <di:waypoint x="1272" y="278" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_1rufoz2" bpmnElement="Flow_05pbieq">
+        <di:waypoint x="910" y="277" />
+        <di:waypoint x="955" y="277" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16if7wo_di" bpmnElement="Flow_16if7wo">
+        <di:waypoint x="1055" y="281" />
+        <di:waypoint x="1100" y="281" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/CaseworkerMakesDecisionGATest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/CaseworkerMakesDecisionGATest.java
@@ -1,0 +1,118 @@
+package uk.gov.hmcts.reform.civil.bpmn;
+
+import org.camunda.bpm.engine.externaltask.ExternalTask;
+import org.camunda.bpm.engine.variable.VariableMap;
+import org.camunda.bpm.engine.variable.Variables;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class CaseworkerMakesDecisionGATest extends BpmnBaseJudgeGASpecTest {
+
+    private static final String MESSAGE_NAME = "APPROVE_CONSENT_ORDER";
+    private static final String PROCESS_ID = "APPROVE_CONSENT_ORDER_PROCESS_ID";
+
+    private static final String GENERATE_CONSENT_ORDER_EVENT = "GENERATE_JUDGES_FORM";
+    private static final String GENERATE_CONSENT_ORDER_ACTIVITY_ID = "GenerateConsentOrderDocument";
+
+    private static final String ADD_PDF_EVENT = "ADD_PDF_TO_MAIN_CASE";
+    private static final String ADD_PDF_ID = "AddDocumentToParentCase";
+
+    private static final String NOTIFY_CONSENT_ORDER_CLAIMANT_EVENT = "START_APPLICANT_NOTIFICATION_PROCESS_MAKE_DECISION";
+    private static final String NOTIFY_CONSENT_ORDER_CLAIMANT_ACTIVITY_ID = "NotifyConsentOrderClaimant";
+    private static final String NOTIFY_CONSENT_ORDER_DEFENDANT_EVENT = "START_RESPONDENT_NOTIFICATION_PROCESS_MAKE_DECISION";
+    private static final String NOTIFY_CONSENT_ORDER_DEFENDANT_ACTIVITY_ID = "NotifyConsentOrderDefendant";
+
+    public CaseworkerMakesDecisionGATest() {
+        super("caseworker_makes_decision_general_application.bpmn", PROCESS_ID);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"true", "false"})
+    void shouldSuccessfullyCompleteCreatePDFDocument_whenCalled(Boolean rpaContinuousFeed) {
+        //assert process has started
+        assertFalse(processInstance.isEnded());
+
+        //assert message start event
+        assertThat(getProcessDefinitionByMessage(MESSAGE_NAME).getKey()).isEqualTo(PROCESS_ID);
+
+        VariableMap variables = Variables.createVariables();
+        variables.put("flowFlags", Map.of("RPA_CONTINUOUS_FEED", rpaContinuousFeed));
+
+        //complete the start business process
+        ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
+        assertCompleteExternalTask(
+            startBusiness,
+            START_BUSINESS_TOPIC,
+            START_BUSINESS_EVENT,
+            START_BUSINESS_ACTIVITY,
+            variables
+        );
+        //Generate Hearing Notice Document
+        ExternalTask generateHearingNoticeDocument = assertNextExternalTask(MAKE_DECISION_CASE_EVENT);
+        assertCompleteExternalTask(
+            generateHearingNoticeDocument,
+            MAKE_DECISION_CASE_EVENT,
+            GENERATE_CONSENT_ORDER_EVENT,
+            GENERATE_CONSENT_ORDER_ACTIVITY_ID,
+            variables
+        );
+
+        //Link Document to main case event
+        ExternalTask addDocumentToMainCase = assertNextExternalTask(UPDATE_FROM_GA_CASE_EVENT);
+        assertCompleteExternalTask(
+            addDocumentToMainCase,
+            UPDATE_FROM_GA_CASE_EVENT,
+            ADD_PDF_EVENT,
+            ADD_PDF_ID,
+            variables
+        );
+
+        //Notify Hearing Notice Claimant
+        ExternalTask notifyHearingNoticeClaimant = assertNextExternalTask(PROCESS_EXTERNAL_CASE_EVENT);
+        assertCompleteExternalTask(
+            notifyHearingNoticeClaimant,
+            PROCESS_EXTERNAL_CASE_EVENT,
+            NOTIFY_CONSENT_ORDER_CLAIMANT_EVENT,
+            NOTIFY_CONSENT_ORDER_CLAIMANT_ACTIVITY_ID,
+            variables
+        );
+
+        //Notify Hearing Notice Defendant(s)
+        ExternalTask notifyHearingNoticeDefendant = assertNextExternalTask(PROCESS_EXTERNAL_CASE_EVENT);
+        assertCompleteExternalTask(
+            notifyHearingNoticeDefendant,
+            PROCESS_EXTERNAL_CASE_EVENT,
+            NOTIFY_CONSENT_ORDER_DEFENDANT_EVENT,
+            NOTIFY_CONSENT_ORDER_DEFENDANT_ACTIVITY_ID,
+            variables
+        );
+
+        //end business process
+        ExternalTask endBusinessProcess = assertNextExternalTask(END_BUSINESS_PROCESS);
+        completeBusinessProcess(endBusinessProcess);
+
+        assertNoExternalTasksLeft();
+    }
+
+    @Test
+    void shouldAbort_whenStartBusinessProcessThrowsAnError() {
+        //assert process has started
+        assertFalse(processInstance.isEnded());
+
+        //assert message start event
+        assertThat(getProcessDefinitionByMessage(MESSAGE_NAME).getKey()).isEqualTo(PROCESS_ID);
+
+        //fail the start business process
+        ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
+        assertFailExternalTask(startBusiness, START_BUSINESS_TOPIC, START_BUSINESS_EVENT, START_BUSINESS_ACTIVITY);
+
+        assertNoExternalTasksLeft();
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/CaseworkerMakesDecisionGATest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/CaseworkerMakesDecisionGATest.java
@@ -23,9 +23,11 @@ public class CaseworkerMakesDecisionGATest extends BpmnBaseJudgeGASpecTest {
     private static final String ADD_PDF_EVENT = "ADD_PDF_TO_MAIN_CASE";
     private static final String ADD_PDF_ID = "AddDocumentToParentCase";
 
-    private static final String NOTIFY_CONSENT_ORDER_CLAIMANT_EVENT = "START_APPLICANT_NOTIFICATION_PROCESS_MAKE_DECISION";
+    private static final String NOTIFY_CONSENT_ORDER_CLAIMANT_EVENT =
+        "START_APPLICANT_NOTIFICATION_PROCESS_MAKE_DECISION";
     private static final String NOTIFY_CONSENT_ORDER_CLAIMANT_ACTIVITY_ID = "NotifyConsentOrderClaimant";
-    private static final String NOTIFY_CONSENT_ORDER_DEFENDANT_EVENT = "START_RESPONDENT_NOTIFICATION_PROCESS_MAKE_DECISION";
+    private static final String NOTIFY_CONSENT_ORDER_DEFENDANT_EVENT =
+        "START_RESPONDENT_NOTIFICATION_PROCESS_MAKE_DECISION";
     private static final String NOTIFY_CONSENT_ORDER_DEFENDANT_ACTIVITY_ID = "NotifyConsentOrderDefendant";
 
     public CaseworkerMakesDecisionGATest() {
@@ -53,7 +55,7 @@ public class CaseworkerMakesDecisionGATest extends BpmnBaseJudgeGASpecTest {
             START_BUSINESS_ACTIVITY,
             variables
         );
-        //Generate Hearing Notice Document
+        //Generate Consent Order Document
         ExternalTask generateHearingNoticeDocument = assertNextExternalTask(MAKE_DECISION_CASE_EVENT);
         assertCompleteExternalTask(
             generateHearingNoticeDocument,
@@ -73,7 +75,7 @@ public class CaseworkerMakesDecisionGATest extends BpmnBaseJudgeGASpecTest {
             variables
         );
 
-        //Notify Hearing Notice Claimant
+        //Notify Consent Order Claimant
         ExternalTask notifyHearingNoticeClaimant = assertNextExternalTask(PROCESS_EXTERNAL_CASE_EVENT);
         assertCompleteExternalTask(
             notifyHearingNoticeClaimant,
@@ -83,7 +85,7 @@ public class CaseworkerMakesDecisionGATest extends BpmnBaseJudgeGASpecTest {
             variables
         );
 
-        //Notify Hearing Notice Defendant(s)
+        //Notify Consent Order Defendant(s)
         ExternalTask notifyHearingNoticeDefendant = assertNextExternalTask(PROCESS_EXTERNAL_CASE_EVENT);
         assertCompleteExternalTask(
             notifyHearingNoticeDefendant,


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x ] README and other documentation has been updated / added (if needed)
- [x ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-7931

### Change description ###

A new template is required for when a caseworker decides to approve a consent order. Once the caseworker has reviewed and decided to approve the consent order, they will be directed to a screen with the Order that is being approved. Once they have made any edits and they submit the order, they are directed to a preview document screen which should contain a link to the populated template.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
