### PR TITLE
CIV-9806 - Generate Defendant Response PDF and DQs when Welsh has been selected

### DIFF
--- a/src/main/resources/camunda/defendant_response_cui.bpmn
+++ b/src/main/resources/camunda/defendant_response_cui.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_18h9iji" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.10.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_18h9iji" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.9.0">
   <bpmn:process id="DEFENDANT_RESPONSE_PROCESS_ID_CUI" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="start">
       <bpmn:outgoing>Flow_01gz2ld</bpmn:outgoing>
@@ -13,7 +13,6 @@
       <bpmn:extensionElements>
         <camunda:in variables="all" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0zskc69</bpmn:incoming>
       <bpmn:incoming>Flow_0wp7bda</bpmn:incoming>
       <bpmn:outgoing>Flow_0jauxrx</bpmn:outgoing>
     </bpmn:callActivity>
@@ -70,7 +69,7 @@
       <bpmn:outgoing>Flow_0zskc69</bpmn:outgoing>
       <bpmn:outgoing>Flow_1q86awx</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_0zskc69" name="Yes" sourceRef="Gateway_0ycr08v" targetRef="Activity_1m5szz9">
+    <bpmn:sequenceFlow id="Flow_0zskc69" name="Yes" sourceRef="Gateway_0ycr08v" targetRef="GenerateSealedLipDQPdf">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.RESPONDENT_RESPONSE_LANGUAGE_IS_BILINGUAL &amp;&amp; flowFlags.RESPONDENT_RESPONSE_LANGUAGE_IS_BILINGUAL}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_1q86awx" name="No" sourceRef="Gateway_0ycr08v" targetRef="DefendantResponseNotifyApplicantSolicitor1ForCui">
@@ -105,6 +104,7 @@
         </camunda:inputOutput>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_genereateDQLip</bpmn:incoming>
+      <bpmn:incoming>Flow_0zskc69</bpmn:incoming>
       <bpmn:outgoing>Flow_generateLipResponsePdf</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_generateLipResponsePdf" sourceRef="GenerateSealedLipDQPdf" targetRef="GenerateSealedLipResponsePdf" />
@@ -118,6 +118,12 @@
         <bpmndi:BPMNLabel>
           <dc:Bounds x="159" y="241" width="23" height="14" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_15p049m_di" bpmnElement="Event_15p049m">
+        <dc:Bounds x="1572" y="198" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_049xhbq_di" bpmnElement="Activity_1m5szz9">
+        <dc:Bounds x="1390" y="176" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1nraabm_di" bpmnElement="Activity_1nraabm">
         <dc:Bounds x="240" y="173" width="100" height="80" />
@@ -146,12 +152,6 @@
       <bpmndi:BPMNShape id="BPMNShape_1ac20v6" bpmnElement="DefendantLipResponseNotifyDefendant">
         <dc:Bounds x="565" y="176" width="100" height="80" />
         <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_15p049m_di" bpmnElement="Event_15p049m">
-        <dc:Bounds x="1572" y="198" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_049xhbq_di" bpmnElement="Activity_1m5szz9">
-        <dc:Bounds x="1390" y="176" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0mbmpfa" bpmnElement="GenerateSealedLipResponsePdf">
         <dc:Bounds x="1220" y="176" width="100" height="80" />
@@ -207,10 +207,10 @@
       <bpmndi:BPMNEdge id="Flow_0zskc69_di" bpmnElement="Flow_0zskc69">
         <di:waypoint x="790" y="241" />
         <di:waypoint x="790" y="409" />
-        <di:waypoint x="1436" y="409" />
-        <di:waypoint x="1436" y="256" />
+        <di:waypoint x="1110" y="409" />
+        <di:waypoint x="1110" y="260" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1105" y="391" width="18" height="14" />
+          <dc:Bounds x="941" y="391" width="18" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1q86awx_di" bpmnElement="Flow_1q86awx">

--- a/src/main/resources/camunda/defendant_response_cui.bpmn
+++ b/src/main/resources/camunda/defendant_response_cui.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_18h9iji" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.9.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_18h9iji" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.10.0">
   <bpmn:process id="DEFENDANT_RESPONSE_PROCESS_ID_CUI" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="start">
       <bpmn:outgoing>Flow_01gz2ld</bpmn:outgoing>

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/DefendantResponseCuiTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/DefendantResponseCuiTest.java
@@ -106,6 +106,8 @@ public class DefendantResponseCuiTest extends BpmnBaseTest {
 
         assertBusinessProcessHasStarted(variables);
         verifyDefendantLipNotificationOfResponseSubmissionCompleted();
+        verifySealedDQGenerationCompleted();
+        verifySealedResponseGenerationCompleted();
 
         endBusinessProcess();
         assertNoExternalTasksLeft();

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/DefendantResponseCuiTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/DefendantResponseCuiTest.java
@@ -92,7 +92,7 @@ public class DefendantResponseCuiTest extends BpmnBaseTest {
     }
 
     @Test
-    void shouldNotNotifyOrGeneratePdf_whenDefendantResponseBilingual() {
+    void shouldNotNotifyApplicant_whenDefendantResponseBilingual() {
 
         //assert process has started
         assertFalse(processInstance.isEnded());


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-9806


### Change description ###
updated Respond to Claim CUI camunda flow when response language is Bilingual.

![image](https://github.com/hmcts/civil-camunda-bpmn-definition/assets/115545612/5d63406c-e2c7-42b5-84bc-b76cccde9f9e)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
