### PR TITLE
CIV-9929  Upgrade Java and gradle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hmctspublic.azurecr.io/base/java:11-distroless
+FROM hmctspublic.azurecr.io/base/java:17-distroless
 
 COPY build/libs/empty.jar /opt/app/
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,10 @@ plugins {
   id 'application'
   id 'checkstyle'
   id 'jacoco'
-  id 'io.spring.dependency-management' version '1.0.14.RELEASE'
+  id 'io.spring.dependency-management' version '1.0.12.RELEASE'
+//  id 'org.springframework.boot' version '2.5.14'
   id 'org.owasp.dependencycheck' version '8.2.1'
-  id 'com.github.ben-manes.versions' version '0.39.0'
+  id 'com.github.ben-manes.versions' version '0.47.0'
   id 'org.sonarqube' version '3.4.0.2513'
 }
 
@@ -12,9 +13,11 @@ group = 'uk.gov.hmcts.reform'
 version = '0.0.1'
 
 allprojects {
-
-  sourceCompatibility = '11'
-  targetCompatibility = '11'
+  java {
+    toolchain {
+      languageVersion = JavaLanguageVersion.of(17)
+    }
+  }
 
   apply plugin: 'java'
   apply plugin: 'jacoco'
@@ -24,13 +27,13 @@ allprojects {
 
   checkstyle {
     maxWarnings = 0
-    toolVersion = '8.29'
+    toolVersion = '10.4'
     getConfigDirectory().set(new File(rootDir, 'config/checkstyle'))
   }
 
   jacoco {
-    toolVersion = '0.8.5' // jacocoMavenPluginVersion
-    reportsDir = file("$buildDir/reports/jacoco")
+    toolVersion = '0.8.8' // jacocoMavenPluginVersion
+    reportsDirectory = file("$buildDir/reports/jacoco")
   }
 
 // before committing a change, make sure task still works
@@ -104,17 +107,11 @@ allprojects {
 
   repositories {
     mavenLocal()
-    jcenter()
     mavenCentral()
     maven {
-      url "https://dl.bintray.com/hmcts/hmcts-maven"
+      url "https://jitpack.io"
     }
-    maven {
-      url  "http://repo.spring.io/milestone"
-    }
-    maven {
-      url  "https://repo.spring.io/libs-milestone"
-    }
+    jcenter()
   }
 }
 
@@ -135,8 +132,8 @@ test {
 }
 
 task awaitApplicationReadiness(type: Exec, description: 'Awaits until application is ready.') {
-  commandLine './bin/wait-for.sh', System.env.URL
-  commandLine './bin/wait-for.sh', System.env.TEST_URL
+  commandLine './bin/wait-for.sh', System.getenv('URL') ?: 'https://localhost:4100'
+  commandLine './bin/wait-for.sh', System.getenv('TEST_URL')?: 'https://localhost:4100'
 }
 
 task runCosTests(type: Exec, description: 'Runs DJ Api functional tests.') {

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -34,7 +34,7 @@
   </module>
   <module name="SuppressWarningsFilter" />
   <module name="LineLength">
-    <property name="max" value="120"/>
+    <property name="max" value="180"/>
     <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
   </module>
   <module name="TreeWalker">
@@ -94,7 +94,9 @@
     <module name="MultipleVariableDeclarations"/>
     <module name="ArrayTypeStyle"/>
     <module name="MissingSwitchDefault"/>
-    <module name="FallThrough"/>
+    <module name="FallThrough">
+      <property name="reliefPattern" value="FALL?[ -]?THROUGH"/>
+    </module>
     <module name="UpperEll"/>
     <module name="ModifierOrder"/>
     <module name="EmptyLineSeparator">
@@ -199,11 +201,6 @@
     </module>
     <module name="OverloadMethodsDeclarationOrder"/>
     <module name="VariableDeclarationUsageDistance"/>
-    <module name="CustomImportOrder">
-      <property name="sortImportsInGroupAlphabetically" value="true"/>
-      <property name="separateLineBetweenGroups" value="true"/>
-      <property name="customImportOrderRules" value="THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE###STATIC"/>
-    </module>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceBefore">
       <property name="tokens"
@@ -215,7 +212,7 @@
       <property name="option" value="NL"/>
       <property name="tokens"
                 value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR,
-                    LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF "/>
+                    LT, MINUS, MOD, NOT_EQUAL, QUESTION, SL, SR, STAR, METHOD_REF "/>
     </module>
     <module name="AnnotationLocation">
       <property name="id" value="AnnotationLocationMostCases"/>
@@ -238,12 +235,6 @@
       <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
       <property name="target"
                 value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
-    </module>
-    <module name="JavadocMethod">
-      <property name="scope" value="nothing"/>
-      <property name="allowMissingParamTags" value="true"/>
-      <property name="allowMissingReturnTag" value="true"/>
-      <property name="allowedAnnotations" value="Override, Test"/>
     </module>
     <module name="MethodName">
       <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
We have noticed deprecated configuration in HMCTS_a_to_c/civil-camunda-bpmn-definition
Please upgrade to Java 17
This configuration will stop working by 01/08/2023


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
