### PR TITLE
CIV-11523 Revoking access to claim for claimant LiP after NoC and and representative assigned

### DIFF
--- a/src/main/resources/camunda/apply_noc_decision_lip.bpmn
+++ b/src/main/resources/camunda/apply_noc_decision_lip.bpmn
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1xagno6" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.14.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.19.0">
+  <bpmn:collaboration id="Collaboration_0lkiw1g">
+    <bpmn:participant id="Participant_1nspjir" name="Apply NoC Decision for Lip" processRef="APPLY_NOC_DECISION_LIP" />
+  </bpmn:collaboration>
+  <bpmn:process id="APPLY_NOC_DECISION_LIP" isExecutable="true">
+    <bpmn:serviceTask id="UpdateCaseDetailsAfterNoC" name="Update case details" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">UPDATE_CASE_DETAILS_AFTER_NOC</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_00ec3ti</bpmn:incoming>
+      <bpmn:outgoing>Flow_1bgy1m8</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_0l4t4tn">
+      <bpmn:incoming>Flow_1s0jw89</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="Activity_0czttms" name="Start Business Process" calledElement="StartBusinessProcess">
+      <bpmn:extensionElements>
+        <camunda:in variables="all" />
+        <camunda:out variables="all" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0dm1zjw</bpmn:incoming>
+      <bpmn:outgoing>Flow_00ec3ti</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:startEvent id="Event_Apply_NoC_Decision" name="Start">
+      <bpmn:outgoing>Flow_0dm1zjw</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_15b4bh3" messageRef="Message_14dl5pe" />
+    </bpmn:startEvent>
+    <bpmn:boundaryEvent id="Event_0rh0701" name="Abort" attachedToRef="Activity_0czttms">
+      <bpmn:outgoing>Flow_1s0jw89</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_1wb1sxi" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_00ec3ti" sourceRef="Activity_0czttms" targetRef="UpdateCaseDetailsAfterNoC" />
+    <bpmn:sequenceFlow id="Flow_1s0jw89" sourceRef="Event_0rh0701" targetRef="Event_0l4t4tn" />
+    <bpmn:sequenceFlow id="Flow_0dm1zjw" sourceRef="Event_Apply_NoC_Decision" targetRef="Activity_0czttms" />
+    <bpmn:sequenceFlow id="Flow_1x9k7i6" sourceRef="Activity_EndBusinessProcess" targetRef="Event_1ryj0ug" />
+    <bpmn:sequenceFlow id="Flow_1bgy1m8" sourceRef="UpdateCaseDetailsAfterNoC" targetRef="Activity_EndBusinessProcess" />
+    <bpmn:callActivity id="Activity_EndBusinessProcess" name="End Business Process" calledElement="EndBusinessProcess">
+      <bpmn:extensionElements>
+        <camunda:in variables="all" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1bgy1m8</bpmn:incoming>
+      <bpmn:outgoing>Flow_1x9k7i6</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="Event_1ryj0ug">
+      <bpmn:incoming>Flow_1x9k7i6</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:message id="Message_14dl5pe" name="APPLY_NOC_DECISION_LIP" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0lkiw1g">
+      <bpmndi:BPMNShape id="Participant_1nspjir_di" bpmnElement="Participant_1nspjir" isHorizontal="true">
+        <dc:Bounds x="159" y="69" width="1730" height="420" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0dev963" bpmnElement="UpdateCaseDetailsAfterNoC">
+        <dc:Bounds x="509" y="227" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0l4t4tn_di" bpmnElement="Event_0l4t4tn">
+        <dc:Bounds x="371" y="119" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1o27yhv_di" bpmnElement="Activity_0czttms">
+        <dc:Bounds x="339" y="227" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0rioham_di" bpmnElement="Event_Apply_NoC_Decision">
+        <dc:Bounds x="241" y="249" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="248" y="292" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_19xyncl_di" bpmnElement="Activity_EndBusinessProcess">
+        <dc:Bounds x="670" y="227" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ryj0ug_di" bpmnElement="Event_1ryj0ug">
+        <dc:Bounds x="872" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_056imgr_di" bpmnElement="Event_0rh0701">
+        <dc:Bounds x="371" y="209" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="347" y="179" width="26" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_00ec3ti_di" bpmnElement="Flow_00ec3ti">
+        <di:waypoint x="439" y="267" />
+        <di:waypoint x="509" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1s0jw89_di" bpmnElement="Flow_1s0jw89">
+        <di:waypoint x="389" y="209" />
+        <di:waypoint x="389" y="155" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0dm1zjw_di" bpmnElement="Flow_0dm1zjw">
+        <di:waypoint x="277" y="267" />
+        <di:waypoint x="339" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1x9k7i6_di" bpmnElement="Flow_1x9k7i6">
+        <di:waypoint x="770" y="267" />
+        <di:waypoint x="872" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1bgy1m8_di" bpmnElement="Flow_1bgy1m8">
+        <di:waypoint x="609" y="269" />
+        <di:waypoint x="670" y="270" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ApplyNocDecisionLipTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ApplyNocDecisionLipTest.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.reform.civil.bpmn;
+
+import org.camunda.bpm.engine.externaltask.ExternalTask;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class ApplyNocDecisionLipTest  extends BpmnBaseTest {
+
+    public static final String MESSAGE_NAME = "APPLY_NOC_DECISION_LIP";
+    public static final String PROCESS_ID = "APPLY_NOC_DECISION_LIP";
+
+    public ApplyNocDecisionLipTest() {
+        super("apply_noc_decision_lip.bpmn", PROCESS_ID);
+    }
+
+    @Test
+    void shouldRunProcess() {
+        //assert process has started
+        assertFalse(processInstance.isEnded());
+        //complete the start business process
+        ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
+        assertCompleteExternalTask(
+            startBusiness,
+            START_BUSINESS_TOPIC,
+            START_BUSINESS_EVENT,
+            START_BUSINESS_ACTIVITY
+        );
+
+        //complete updating case details
+        ExternalTask updateCaseDetails = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            updateCaseDetails,
+            PROCESS_CASE_EVENT,
+            "UPDATE_CASE_DETAILS_AFTER_NOC",
+            "UpdateCaseDetailsAfterNoC"
+        );
+
+        //end business process
+        ExternalTask endBusinessProcess = assertNextExternalTask(END_BUSINESS_PROCESS);
+        completeBusinessProcess(endBusinessProcess);
+
+        assertNoExternalTasksLeft();
+    }
+}


### PR DESCRIPTION

![image](https://github.com/hmcts/civil-camunda-bpmn-definition/assets/134285996/5c0a9c50-41f8-4bda-af25-6c1c5c06fd13)


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-11523

### Change description ###
Revoking access to claim for claimant LiP after NoC and and representative assigned


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
