### PR TITLE
CIV-12997 - Update AHN burndown timers

### DIFF
--- a/src/main/resources/camunda/spec-automated-hearing-notice-scheduler.bpmn
+++ b/src/main/resources/camunda/spec-automated-hearing-notice-scheduler.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_14qf5vi" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_14qf5vi" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.19.0">
   <bpmn:process id="SpecAutomatedHearingNoticeScheduler" name="Spec Automated Hearing Notice Scheduler" isExecutable="true">
     <bpmn:subProcess id="SchedulerSubProcess" name="Scheduler Sub Process">
       <bpmn:incoming>Flow_090bysl</bpmn:incoming>
@@ -22,11 +22,11 @@
         <bpmn:outgoing>Flow_06gwrwj</bpmn:outgoing>
         <bpmn:outgoing>Flow_1pimcbh</bpmn:outgoing>
       </bpmn:exclusiveGateway>
-      <bpmn:intermediateCatchEvent id="Event_0myktic">
+      <bpmn:intermediateCatchEvent id="Event_0myktic" name="5 Minute Wait">
         <bpmn:incoming>Flow_1pimcbh</bpmn:incoming>
         <bpmn:outgoing>Flow_18vgulo</bpmn:outgoing>
         <bpmn:timerEventDefinition id="TimerEventDefinition_1ja9zkg">
-          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT30S</bpmn:timeDuration>
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT300S</bpmn:timeDuration>
         </bpmn:timerEventDefinition>
       </bpmn:intermediateCatchEvent>
       <bpmn:sequenceFlow id="Flow_0srigb3" sourceRef="Event_HearingNoticeScheduler" targetRef="SpecHearingNoticeSchedulerId" />
@@ -83,45 +83,10 @@
   <bpmn:message id="Message_0slk3de" name="TRIGGER_HEARING_NOTICES" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="SpecAutomatedHearingNoticeScheduler">
-      <bpmndi:BPMNEdge id="Flow_0382rll_di" bpmnElement="Flow_0382rll">
-        <di:waypoint x="1020" y="458" />
-        <di:waypoint x="1020" y="478" />
-        <di:waypoint x="1220" y="478" />
-        <di:waypoint x="1220" y="278" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_19zr3vr_di" bpmnElement="Flow_19zr3vr">
-        <di:waypoint x="1100" y="260" />
-        <di:waypoint x="1202" y="260" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_090bysl_di" bpmnElement="Flow_090bysl">
-        <di:waypoint x="248" y="260" />
-        <di:waypoint x="340" y="260" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Activity_15foiay_di" bpmnElement="SchedulerSubProcess" isExpanded="true">
         <dc:Bounds x="340" y="80" width="760" height="360" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1pimcbh_di" bpmnElement="Flow_1pimcbh">
-        <di:waypoint x="720" y="255" />
-        <di:waypoint x="720" y="178" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_06gwrwj_di" bpmnElement="Flow_06gwrwj">
-        <di:waypoint x="745" y="280" />
-        <di:waypoint x="822" y="280" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0tjw87e_di" bpmnElement="Flow_0tjw87e">
-        <di:waypoint x="610" y="280" />
-        <di:waypoint x="695" y="280" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_18vgulo_di" bpmnElement="Flow_18vgulo">
-        <di:waypoint x="702" y="160" />
-        <di:waypoint x="560" y="160" />
-        <di:waypoint x="560" y="240" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0srigb3_di" bpmnElement="Flow_0srigb3">
-        <di:waypoint x="418" y="280" />
-        <di:waypoint x="510" y="280" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Activity_1ydkywr_di" bpmnElement="SpecHearingNoticeSchedulerId">
         <dc:Bounds x="510" y="240" width="100" height="80" />
         <bpmndi:BPMNLabel />
@@ -134,6 +99,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0hejd40_di" bpmnElement="Event_0myktic">
         <dc:Bounds x="702" y="142" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="686" y="123" width="67" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1gl7lj1_di" bpmnElement="Event_HearingNoticeScheduler">
         <dc:Bounds x="382" y="262" width="36" height="36" />
@@ -149,6 +117,27 @@
         <dc:Bounds x="780" y="340" width="270" height="30" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0srigb3_di" bpmnElement="Flow_0srigb3">
+        <di:waypoint x="418" y="280" />
+        <di:waypoint x="510" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_18vgulo_di" bpmnElement="Flow_18vgulo">
+        <di:waypoint x="702" y="160" />
+        <di:waypoint x="560" y="160" />
+        <di:waypoint x="560" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0tjw87e_di" bpmnElement="Flow_0tjw87e">
+        <di:waypoint x="610" y="280" />
+        <di:waypoint x="695" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06gwrwj_di" bpmnElement="Flow_06gwrwj">
+        <di:waypoint x="745" y="280" />
+        <di:waypoint x="822" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1pimcbh_di" bpmnElement="Flow_1pimcbh">
+        <di:waypoint x="720" y="255" />
+        <di:waypoint x="720" y="178" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Association_1804e5f_di" bpmnElement="Association_1804e5f">
         <di:waypoint x="720" y="216.5" />
         <di:waypoint x="768" y="165" />
@@ -180,6 +169,20 @@
           <dc:Bounds x="940" y="465" width="40" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_090bysl_di" bpmnElement="Flow_090bysl">
+        <di:waypoint x="248" y="260" />
+        <di:waypoint x="340" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19zr3vr_di" bpmnElement="Flow_19zr3vr">
+        <di:waypoint x="1100" y="260" />
+        <di:waypoint x="1202" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0382rll_di" bpmnElement="Flow_0382rll">
+        <di:waypoint x="1020" y="458" />
+        <di:waypoint x="1020" y="478" />
+        <di:waypoint x="1220" y="478" />
+        <di:waypoint x="1220" y="278" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Association_0v4ocai_di" bpmnElement="Association_0v4ocai">
         <di:waypoint x="1008" y="453" />
         <di:waypoint x="964" y="500" />

--- a/src/main/resources/camunda/unspec-automated-hearing-notice-scheduler.bpmn
+++ b/src/main/resources/camunda/unspec-automated-hearing-notice-scheduler.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_14qf5vi" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.12.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_14qf5vi" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.19.0">
   <bpmn:process id="UnspecAutomatedHearingNoticeScheduler" name="Unspec Automated Hearing Notice Scheduler" isExecutable="true">
     <bpmn:endEvent id="Event_004p472">
       <bpmn:incoming>Flow_09zo7hz</bpmn:incoming>
@@ -30,11 +30,11 @@
       <bpmn:endEvent id="Event_1x6es2j">
         <bpmn:incoming>Flow_0x9nvkc</bpmn:incoming>
       </bpmn:endEvent>
-      <bpmn:intermediateCatchEvent id="Event_0l091sv">
+      <bpmn:intermediateCatchEvent id="Event_0l091sv" name="5 Minute Wait">
         <bpmn:incoming>Flow_1vpfqmi</bpmn:incoming>
         <bpmn:outgoing>Flow_0mn6znn</bpmn:outgoing>
         <bpmn:timerEventDefinition id="TimerEventDefinition_0j3t7dk">
-          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT30S</bpmn:timeDuration>
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT300S</bpmn:timeDuration>
         </bpmn:timerEventDefinition>
       </bpmn:intermediateCatchEvent>
       <bpmn:sequenceFlow id="Flow_1vpfqmi" sourceRef="Gateway_0cjf4q7" targetRef="Event_0l091sv">
@@ -85,23 +85,6 @@
   <bpmn:message id="Message_1itf61f" name="StartHearingNoticeScheduler" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="UnspecAutomatedHearingNoticeScheduler">
-      <bpmndi:BPMNEdge id="Flow_0punsjq_di" bpmnElement="Flow_0punsjq">
-        <di:waypoint x="950" y="448" />
-        <di:waypoint x="950" y="468" />
-        <di:waypoint x="1210" y="468" />
-        <di:waypoint x="1210" y="273" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_09zo7hz_di" bpmnElement="Flow_09zo7hz">
-        <di:waypoint x="1070" y="255" />
-        <di:waypoint x="1192" y="255" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_155del8_di" bpmnElement="Flow_155del8">
-        <di:waypoint x="248" y="255" />
-        <di:waypoint x="350" y="255" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Event_0lbh5uj_di" bpmnElement="StartEvent_1">
-        <dc:Bounds x="212" y="237" width="36" height="36" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_004p472_di" bpmnElement="Event_004p472">
         <dc:Bounds x="1192" y="237" width="36" height="36" />
       </bpmndi:BPMNShape>
@@ -109,27 +92,6 @@
         <dc:Bounds x="350" y="80" width="720" height="350" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_0ahqskv_di" bpmnElement="Flow_0ahqskv">
-        <di:waypoint x="438" y="280" />
-        <di:waypoint x="510" y="280" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="BPMNEdge_0g3egxb" bpmnElement="Flow_0mn6znn">
-        <di:waypoint x="702" y="160" />
-        <di:waypoint x="560" y="160" />
-        <di:waypoint x="560" y="240" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="BPMNEdge_17ctxf6" bpmnElement="Flow_1vpfqmi">
-        <di:waypoint x="720" y="255" />
-        <di:waypoint x="720" y="178" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="BPMNEdge_0zmljf8" bpmnElement="Flow_0x9nvkc">
-        <di:waypoint x="745" y="280" />
-        <di:waypoint x="822" y="280" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="BPMNEdge_0cyx9mt" bpmnElement="Flow_108mq3g">
-        <di:waypoint x="610" y="280" />
-        <di:waypoint x="695" y="280" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="BPMNShape_1588a57" bpmnElement="UnspecHearingNoticeSchedulerId">
         <dc:Bounds x="510" y="240" width="100" height="80" />
         <bpmndi:BPMNLabel />
@@ -142,6 +104,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0sz94h3" bpmnElement="Event_0l091sv">
         <dc:Bounds x="702" y="142" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="687" y="123" width="67" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0jjklb5_di" bpmnElement="Event_0jjklb5">
         <dc:Bounds x="402" y="262" width="36" height="36" />
@@ -154,6 +119,27 @@
         <dc:Bounds x="770" y="150" width="273" height="30" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_0cyx9mt" bpmnElement="Flow_108mq3g">
+        <di:waypoint x="610" y="280" />
+        <di:waypoint x="695" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_0zmljf8" bpmnElement="Flow_0x9nvkc">
+        <di:waypoint x="745" y="280" />
+        <di:waypoint x="822" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_17ctxf6" bpmnElement="Flow_1vpfqmi">
+        <di:waypoint x="720" y="255" />
+        <di:waypoint x="720" y="178" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_0g3egxb" bpmnElement="Flow_0mn6znn">
+        <di:waypoint x="702" y="160" />
+        <di:waypoint x="560" y="160" />
+        <di:waypoint x="560" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ahqskv_di" bpmnElement="Flow_0ahqskv">
+        <di:waypoint x="438" y="280" />
+        <di:waypoint x="510" y="280" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="BPMNEdge_0omrjrp" bpmnElement="Association_0tlfaea">
         <di:waypoint x="784" y="280" />
         <di:waypoint x="810" y="340" />
@@ -162,6 +148,9 @@
         <di:waypoint x="720" y="217" />
         <di:waypoint x="770" y="176" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0lbh5uj_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="212" y="237" width="36" height="36" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="TextAnnotation_1f1xat5_di" bpmnElement="TextAnnotation_1f1xat5">
         <dc:Bounds x="810" y="490" width="140" height="29" />
         <bpmndi:BPMNLabel />
@@ -176,6 +165,20 @@
           <dc:Bounds x="880" y="455" width="40" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_09zo7hz_di" bpmnElement="Flow_09zo7hz">
+        <di:waypoint x="1070" y="255" />
+        <di:waypoint x="1192" y="255" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0punsjq_di" bpmnElement="Flow_0punsjq">
+        <di:waypoint x="950" y="448" />
+        <di:waypoint x="950" y="468" />
+        <di:waypoint x="1210" y="468" />
+        <di:waypoint x="1210" y="273" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_155del8_di" bpmnElement="Flow_155del8">
+        <di:waypoint x="248" y="255" />
+        <di:waypoint x="350" y="255" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Association_1wnz1gx_di" bpmnElement="Association_1wnz1gx">
         <di:waypoint x="936" y="441" />
         <di:waypoint x="878" y="490" />

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/SpecAutomatedHearingNoticeSchedulerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/SpecAutomatedHearingNoticeSchedulerTest.java
@@ -43,7 +43,7 @@ class SpecAutomatedHearingNoticeSchedulerTest extends BpmnBaseTest {
 
         String cronString = "0 0 0,12 ? * * *";
         assertThat(jobDefinitions.get(0).getJobConfiguration()).isEqualTo("CYCLE: " + cronString);
-        assertThat(jobDefinitions.get(1).getJobConfiguration()).isEqualTo("DURATION: PT30S");
+        assertThat(jobDefinitions.get(1).getJobConfiguration()).isEqualTo("DURATION: PT300S");
         assertThat(jobDefinitions.get(2).getJobConfiguration()).isEqualTo("DURATION: PT30M");
 
         assertCronTriggerFiresAtExpectedTime(

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/UnspecAutomatedHearingNoticeSchedulerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/UnspecAutomatedHearingNoticeSchedulerTest.java
@@ -41,7 +41,7 @@ class UnspecAutomatedHearingNoticeSchedulerTest extends BpmnBaseTest {
 
         String cronString = "0 0 0,12 ? * * *";
         assertThat(jobDefinitions.get(0).getJobConfiguration()).isEqualTo("CYCLE: " + cronString);
-        assertThat(jobDefinitions.get(1).getJobConfiguration()).isEqualTo("DURATION: PT30S");
+        assertThat(jobDefinitions.get(1).getJobConfiguration()).isEqualTo("DURATION: PT300S");
         assertThat(jobDefinitions.get(2).getJobConfiguration()).isEqualTo("DURATION: PT30M");
 
         //get external tasks


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-12997


### Change description ###
- Update timer from 30s to 5 mins before calling unnotified again
- Giving more time for camunda processes to finish before making an expensive request to HMC


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
