### PR TITLE
CIV-14748 - Revert "CIV-14748 Add 5 Minutes Delay Before Notifications"

### DIFF
--- a/src/main/resources/camunda/amend_restitch_bundle.bpmn
+++ b/src/main/resources/camunda/amend_restitch_bundle.bpmn
@@ -33,7 +33,7 @@
         <camunda:in variables="all" />
         <camunda:out variables="all" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0edlo09</bpmn:incoming>
+      <bpmn:incoming>Flow_87785545545</bpmn:incoming>
       <bpmn:outgoing>Flow_78545522545</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:endEvent id="Event_55878855778">
@@ -44,7 +44,7 @@
       <bpmn:errorEventDefinition id="ErrorEventDefinition_09jmy6o" />
     </bpmn:boundaryEvent>
     <bpmn:sequenceFlow id="Flow_778754554" sourceRef="Event_0kza4it" targetRef="Event_55878855778" />
-    <bpmn:sequenceFlow id="Flow_87785545545" sourceRef="Event_191090" targetRef="Event_1tsukbp" />
+    <bpmn:sequenceFlow id="Flow_87785545545" sourceRef="Event_191090" targetRef="Activity_7842144454" />
     <bpmn:sequenceFlow id="Flow_78545522545" sourceRef="Activity_7842144454" targetRef="NotifyClaimantAmendRestitchBundle" />
     <bpmn:serviceTask id="NotifyDefendantAmendRestitchBundle" name="Notify Defendant" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
@@ -77,101 +77,82 @@
       <bpmn:outgoing>Flow_0qh9s34</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_0qh9s34" sourceRef="CreateAmendRestitchBundleDashboardNotificationsForDefendant" targetRef="Activity_120199855" />
-    <bpmn:intermediateCatchEvent id="Event_1tsukbp" name="Delay 5 Minutes">
-      <bpmn:incoming>Flow_87785545545</bpmn:incoming>
-      <bpmn:outgoing>Flow_0edlo09</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0g8k5cp">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT5M</bpmn:timeDuration>
-      </bpmn:timerEventDefinition>
-    </bpmn:intermediateCatchEvent>
-    <bpmn:sequenceFlow id="Flow_0edlo09" sourceRef="Event_1tsukbp" targetRef="Activity_7842144454" />
   </bpmn:process>
   <bpmn:error id="Error_0lou1w7" name="StartBusinessAbort" errorCode="ABORT" />
   <bpmn:message id="Message_07sm7e9" name="AMEND_RESTITCH_BUNDLE" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="AMEND_RESTITCH_BUNDLE">
       <bpmndi:BPMNShape id="Activity_0ipbyde_di" bpmnElement="NotifyClaimantAmendRestitchBundle">
-        <dc:Bounds x="490" y="165" width="100" height="80" />
+        <dc:Bounds x="420" y="167" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1h61h5s_di" bpmnElement="Event_878884254">
-        <dc:Bounds x="1382" y="193" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_0vk0w99_di" bpmnElement="Event_191090">
+        <dc:Bounds x="152" y="192" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="158" y="235" width="25" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1j68eid_di" bpmnElement="Activity_120199855">
-        <dc:Bounds x="1180" y="171" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_15x2r24_di" bpmnElement="Activity_7842144454">
+        <dc:Bounds x="230" y="167" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1n2x861_di" bpmnElement="Event_55878855778">
         <dc:Bounds x="262" y="79" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1smbj8l" bpmnElement="NotifyDefendantAmendRestitchBundle">
-        <dc:Bounds x="670" y="165" width="100" height="80" />
+        <dc:Bounds x="610" y="167" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1h61h5s_di" bpmnElement="Event_878884254">
+        <dc:Bounds x="1382" y="189" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0qwga33" bpmnElement="CreateAmendRestitchBundleDashboardNotificationsForDefendant">
+        <dc:Bounds x="990" y="167" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1qfub25" bpmnElement="CreateAmendRestitchBundleDashboardNotificationsForClaimant">
-        <dc:Bounds x="850" y="167" width="100" height="80" />
+        <dc:Bounds x="810" y="167" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0qwga33" bpmnElement="CreateAmendRestitchBundleDashboardNotificationsForDefendant">
-        <dc:Bounds x="1020" y="167" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_15x2r24_di" bpmnElement="Activity_7842144454">
-        <dc:Bounds x="320" y="165" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1ltoog8" bpmnElement="Event_1tsukbp">
-        <dc:Bounds x="221" y="190" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="201" y="233" width="80" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0vk0w99_di" bpmnElement="Event_191090">
-        <dc:Bounds x="122" y="190" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="128" y="233" width="25" height="14" />
-        </bpmndi:BPMNLabel>
+      <bpmndi:BPMNShape id="Activity_1j68eid_di" bpmnElement="Activity_120199855">
+        <dc:Bounds x="1180" y="167" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0kza4it_di" bpmnElement="Event_0kza4it">
-        <dc:Bounds x="352" y="147" width="36" height="36" />
+        <dc:Bounds x="262" y="149" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="386" y="128" width="27" height="14" />
+          <dc:Bounds x="296" y="130" width="27" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0x2wz2v_di" bpmnElement="Flow_5845212254">
-        <di:waypoint x="1280" y="211" />
-        <di:waypoint x="1382" y="211" />
+        <di:waypoint x="1280" y="207" />
+        <di:waypoint x="1382" y="207" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1y0ic2q_di" bpmnElement="Flow_778754554">
-        <di:waypoint x="370" y="147" />
-        <di:waypoint x="370" y="97" />
-        <di:waypoint x="298" y="97" />
+        <di:waypoint x="280" y="149" />
+        <di:waypoint x="280" y="115" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_116h4jn_di" bpmnElement="Flow_87785545545">
-        <di:waypoint x="158" y="208" />
-        <di:waypoint x="221" y="208" />
+        <di:waypoint x="188" y="210" />
+        <di:waypoint x="230" y="210" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1a5jscb_di" bpmnElement="Flow_78545522545">
-        <di:waypoint x="420" y="205" />
-        <di:waypoint x="490" y="205" />
+        <di:waypoint x="330" y="207" />
+        <di:waypoint x="420" y="207" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1xckrvu_di" bpmnElement="Flow_1xckrvu544555">
-        <di:waypoint x="770" y="207" />
-        <di:waypoint x="850" y="207" />
+        <di:waypoint x="710" y="208" />
+        <di:waypoint x="810" y="207" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1fxs0vt_di" bpmnElement="Flow_1fxs0vt25554">
-        <di:waypoint x="590" y="205" />
-        <di:waypoint x="670" y="205" />
+        <di:waypoint x="520" y="207" />
+        <di:waypoint x="610" y="207" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1qw3fa2_di" bpmnElement="Flow_1qw3fa2545">
-        <di:waypoint x="950" y="207" />
-        <di:waypoint x="1020" y="207" />
+        <di:waypoint x="910" y="207" />
+        <di:waypoint x="990" y="207" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0qh9s34_di" bpmnElement="Flow_0qh9s34">
-        <di:waypoint x="1120" y="206" />
-        <di:waypoint x="1180" y="206" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0edlo09_di" bpmnElement="Flow_0edlo09">
-        <di:waypoint x="257" y="208" />
-        <di:waypoint x="320" y="208" />
+        <di:waypoint x="1090" y="205" />
+        <di:waypoint x="1180" y="203" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/AmendRestitchBundleTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/AmendRestitchBundleTest.java
@@ -1,15 +1,10 @@
 package uk.gov.hmcts.reform.civil.bpmn;
 
 import org.camunda.bpm.engine.externaltask.ExternalTask;
-import org.camunda.bpm.engine.impl.util.ClockUtil;
-import org.camunda.bpm.engine.management.JobDefinition;
-import org.camunda.bpm.engine.runtime.Job;
 import org.camunda.bpm.engine.variable.VariableMap;
 import org.camunda.bpm.engine.variable.Variables;
 import org.junit.jupiter.api.Test;
 
-import java.util.Date;
-import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -49,7 +44,6 @@ public class AmendRestitchBundleTest extends BpmnBaseTest {
 
     @Test
     void shouldSuccessfullyCompleteAmendRestitchBundle() {
-
         //assert process has started
         assertFalse(processInstance.isEnded());
 
@@ -63,28 +57,13 @@ public class AmendRestitchBundleTest extends BpmnBaseTest {
             CASE_PROGRESSION_ENABLED, true
         ));
 
-        //get jobs
-        List<JobDefinition> jobDefinitions = getJobs();
-
-        //assert that job is as expected
-        assertThat(jobDefinitions).hasSize(1);
-
-        assertThat(jobDefinitions.get(0).getJobType()).isEqualTo("timer-intermediate-transition");
-
-        assertThat(jobDefinitions.get(0).getJobConfiguration()).isEqualTo("DURATION: PT5M");
-
-        Date startTime = new Date();
-        ClockUtil.setCurrentTime(new Date(startTime.getTime() + ((6 * 60 * 1000))));
-
-        executeAllJobs();
-
-        ExternalTask notificationTask;
-
         //complete the start business process
         ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
         assertCompleteExternalTask(startBusiness, START_BUSINESS_TOPIC,
                                    START_BUSINESS_EVENT, START_BUSINESS_ACTIVITY, variables
         );
+
+        ExternalTask notificationTask;
 
         //complete the claimant notification
         notificationTask = assertNextExternalTask(PROCESS_CASE_EVENT);
@@ -123,27 +102,5 @@ public class AmendRestitchBundleTest extends BpmnBaseTest {
         completeBusinessProcess(endBusinessProcess);
 
         assertNoExternalTasksLeft();
-    }
-
-    protected void executeAllJobs() {
-        String nextJobId = getNextExecutableJobId();
-
-        while (nextJobId != null) {
-            try {
-                engine.getManagementService().executeJob(nextJobId);
-            } catch (Throwable t) { /* ignore */
-            }
-            nextJobId = getNextExecutableJobId();
-        }
-
-    }
-
-    protected String getNextExecutableJobId() {
-        List<Job> jobs = engine.getManagementService().createJobQuery().executable().listPage(0, 1);
-        if (jobs.size() == 1) {
-            return jobs.get(0).getId();
-        } else {
-            return null;
-        }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/AmendRestitchBundleTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/AmendRestitchBundleTest.java
@@ -53,7 +53,7 @@ public class AmendRestitchBundleTest extends BpmnBaseTest {
         VariableMap variables = Variables.createVariables();
         variables.put("flowFlags", Map.of(
             UNREPRESENTED_DEFENDANT_ONE, false,
-            DASHBOARD_SERVICE_ENABLED, true,
+            DASHBOARD_SERVICE_ENABLED, true, 
             CASE_PROGRESSION_ENABLED, true
         ));
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/AmendRestitchBundleTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/AmendRestitchBundleTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class AmendRestitchBundleTest extends BpmnBaseTest {
 
-    public static final String MESSAGE_NAME = "AMEND_RESTITCH_BUNDLE";
+    public static final String MESSAGE_NAME = "AMEND_RESTITCH_BUNDLE"; 
     public static final String PROCESS_ID = "AMEND_RESTITCH_BUNDLE";
 
     //CCD CASE EVENT


### PR DESCRIPTION
Reverts hmcts/civil-camunda-bpmn-definition#1059

Due to issue where async return of document does not work even if timer is put before business process:
![image](https://github.com/user-attachments/assets/ffe5219f-15f6-4175-8314-5e95327f86b6)
