### PR TITLE
CIV-15835 - 'Application is offline' dashboard notification not shown to applicant

### DIFF
--- a/src/main/resources/camunda/case_proceeds_in_caseman.bpmn
+++ b/src/main/resources/camunda/case_proceeds_in_caseman.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0rn46su" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.18.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0rn46su" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.9.0">
   <bpmn:process id="CASE_PROCEEDS_IN_CASEMAN" name="Case proceeds in caseman" isExecutable="true" camunda:historyTimeToLive="P90D">
     <bpmn:startEvent id="Event_StartClaimTakenOffline" name="Start">
       <bpmn:outgoing>Flow_NextStartBusinessProcess</bpmn:outgoing>
@@ -13,8 +13,9 @@
       <bpmn:extensionElements>
         <camunda:in variables="all" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0ixumtp</bpmn:incoming>
       <bpmn:incoming>Flow_1ozvyhu</bpmn:incoming>
+      <bpmn:incoming>Flow_GA_Not_Enabled</bpmn:incoming>
+      <bpmn:incoming>Flow_0n61xqe</bpmn:incoming>
       <bpmn:outgoing>Flow_NextEndEvent</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:callActivity id="Activity_StartBusinessProcess" name="Start Business Process" calledElement="StartBusinessProcess">
@@ -133,11 +134,10 @@
           <camunda:inputParameter name="caseEvent">CREATE_CLAIMANT_DASHBOARD_NOTIFICATION_FOR_CASE_PROCEED_OFFLINE</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1o9gd21</bpmn:incoming>
-      <bpmn:incoming>Flow_GA_Not_Enabled</bpmn:incoming>
+      <bpmn:incoming>Flow_0rfdl2o</bpmn:incoming>
       <bpmn:outgoing>Flow_1xenm35</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0rfdl2o" name="Dashboard Service Enabled" sourceRef="Gateway_0sx9s0b" targetRef="Gateway_0wnamaf">
+    <bpmn:sequenceFlow id="Flow_0rfdl2o" name="Dashboard Service Enabled" sourceRef="Gateway_0sx9s0b" targetRef="GenerateClaimantDashboardNotificationCaseProceedOffline">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.DASHBOARD_SERVICE_ENABLED &amp;&amp; flowFlags.DASHBOARD_SERVICE_ENABLED}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_1xenm35" sourceRef="GenerateClaimantDashboardNotificationCaseProceedOffline" targetRef="GenerateDefendantDashboardNotificationCaseProceedOffline" />
@@ -150,7 +150,7 @@
       <bpmn:incoming>Flow_1xenm35</bpmn:incoming>
       <bpmn:outgoing>Flow_0ixumtp</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0ixumtp" sourceRef="GenerateDefendantDashboardNotificationCaseProceedOffline" targetRef="Activity_EndBusinessProcess" />
+    <bpmn:sequenceFlow id="Flow_0ixumtp" sourceRef="GenerateDefendantDashboardNotificationCaseProceedOffline" targetRef="Gateway_1ynrdtq" />
     <bpmn:sequenceFlow id="Flow_1ozvyhu" name="Dashboard Service Disabled" sourceRef="Gateway_0sx9s0b" targetRef="Activity_EndBusinessProcess">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${empty flowFlags.DASHBOARD_SERVICE_ENABLED || !flowFlags.DASHBOARD_SERVICE_ENABLED}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
@@ -160,8 +160,8 @@
           <camunda:inputParameter name="caseEvent">CREATE_DASHBOARD_NOTIFICATION_APPLICATION_PROCEED_OFFLINE_CLAIMANT</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_GA_Enabled</bpmn:incoming>
-      <bpmn:outgoing>Flow_1126ddg</bpmn:outgoing>
+      <bpmn:incoming>Flow_0ow1g6s</bpmn:incoming>
+      <bpmn:outgoing>Flow_17716q5</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:serviceTask id="defendantLipApplicationOfflineDashboardNotification" name="Dashboard Notification For Application Offline Defendant" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
@@ -169,22 +169,22 @@
           <camunda:inputParameter name="caseEvent">CREATE_DASHBOARD_NOTIFICATION_APPLICATION_PROCEED_OFFLINE_DEFENDANT</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1126ddg</bpmn:incoming>
-      <bpmn:outgoing>Flow_1o9gd21</bpmn:outgoing>
+      <bpmn:incoming>Flow_17716q5</bpmn:incoming>
+      <bpmn:outgoing>Flow_0n61xqe</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1o9gd21" sourceRef="defendantLipApplicationOfflineDashboardNotification" targetRef="GenerateClaimantDashboardNotificationCaseProceedOffline" />
-    <bpmn:exclusiveGateway id="Gateway_0wnamaf">
-      <bpmn:incoming>Flow_0rfdl2o</bpmn:incoming>
+    <bpmn:exclusiveGateway id="Gateway_1ynrdtq">
+      <bpmn:incoming>Flow_0ixumtp</bpmn:incoming>
       <bpmn:outgoing>Flow_GA_Not_Enabled</bpmn:outgoing>
-      <bpmn:outgoing>Flow_GA_Enabled</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0ow1g6s</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_GA_Not_Enabled" name="GA Not Enabled" sourceRef="Gateway_0wnamaf" targetRef="GenerateClaimantDashboardNotificationCaseProceedOffline">
+    <bpmn:sequenceFlow id="Flow_GA_Not_Enabled" name="GA Not Enabled" sourceRef="Gateway_1ynrdtq" targetRef="Activity_EndBusinessProcess">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${empty flowFlags.GENERAL_APPLICATION_ENABLED || !flowFlags.GENERAL_APPLICATION_ENABLED}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_GA_Enabled" name="GA Enabled" sourceRef="Gateway_0wnamaf" targetRef="claimantLipApplicationOfflineDashboardNotification">
+    <bpmn:sequenceFlow id="Flow_0ow1g6s" name="GA Enabled" sourceRef="Gateway_1ynrdtq" targetRef="claimantLipApplicationOfflineDashboardNotification">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.GENERAL_APPLICATION_ENABLED &amp;&amp; flowFlags.GENERAL_APPLICATION_ENABLED}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1126ddg" sourceRef="claimantLipApplicationOfflineDashboardNotification" targetRef="defendantLipApplicationOfflineDashboardNotification" />
+    <bpmn:sequenceFlow id="Flow_17716q5" sourceRef="claimantLipApplicationOfflineDashboardNotification" targetRef="defendantLipApplicationOfflineDashboardNotification" />
+    <bpmn:sequenceFlow id="Flow_0n61xqe" sourceRef="defendantLipApplicationOfflineDashboardNotification" targetRef="Activity_EndBusinessProcess" />
   </bpmn:process>
   <bpmn:message id="Message_0slk3de" name="CASE_PROCEEDS_IN_CASEMAN" />
   <bpmn:error id="Error_0t2ju7k" name="StartBusinessAbort" errorCode="ABORT" />
@@ -195,6 +195,9 @@
         <bpmndi:BPMNLabel>
           <dc:Bounds x="158" y="235" width="24" height="14" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0r8yo0r_di" bpmnElement="Event_EndClaimTakenOffline">
+        <dc:Bounds x="2392" y="192" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0emdthr_di" bpmnElement="Activity_StartBusinessProcess">
         <dc:Bounds x="230" y="170" width="100" height="80" />
@@ -233,29 +236,26 @@
       <bpmndi:BPMNShape id="Gateway_0sx9s0b_di" bpmnElement="Gateway_0sx9s0b" isMarkerVisible="true">
         <dc:Bounds x="1605" y="185" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0w5znbg" bpmnElement="defendantLipApplicationOfflineDashboardNotification">
-        <dc:Bounds x="1870" y="460" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_01op09a_di" bpmnElement="GenerateClaimantDashboardNotificationCaseProceedOffline">
+        <dc:Bounds x="1670" y="320" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0r8yo0r_di" bpmnElement="Event_EndClaimTakenOffline">
-        <dc:Bounds x="2392" y="192" width="36" height="36" />
+      <bpmndi:BPMNShape id="BPMNShape_0w5znbg" bpmnElement="defendantLipApplicationOfflineDashboardNotification">
+        <dc:Bounds x="2160" y="450" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1x5rl4x_di" bpmnElement="Activity_EndBusinessProcess">
-        <dc:Bounds x="2220" y="170" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_15vvbke" bpmnElement="GenerateDefendantDashboardNotificationCaseProceedOffline">
-        <dc:Bounds x="2030" y="320" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_01op09a_di" bpmnElement="GenerateClaimantDashboardNotificationCaseProceedOffline">
-        <dc:Bounds x="1870" y="320" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0wnamaf_di" bpmnElement="Gateway_0wnamaf" isMarkerVisible="true">
-        <dc:Bounds x="1605" y="335" width="50" height="50" />
+        <dc:Bounds x="2240" y="170" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1rtq8df" bpmnElement="claimantLipApplicationOfflineDashboardNotification">
-        <dc:Bounds x="1700" y="460" width="100" height="80" />
+        <dc:Bounds x="2030" y="450" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1ynrdtq_di" bpmnElement="Gateway_1ynrdtq" isMarkerVisible="true">
+        <dc:Bounds x="1975" y="335" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_15vvbke" bpmnElement="GenerateDefendantDashboardNotificationCaseProceedOffline">
+        <dc:Bounds x="1810" y="320" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1fn0bf1_di" bpmnElement="Event_1fn0bf1">
@@ -265,7 +265,7 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_1hce35l_di" bpmnElement="Flow_NextEndEvent">
-        <di:waypoint x="2320" y="210" />
+        <di:waypoint x="2340" y="210" />
         <di:waypoint x="2392" y="210" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0yvpi10_di" bpmnElement="Flow_StartBusinessProcessAbort">
@@ -328,49 +328,51 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0rfdl2o_di" bpmnElement="Flow_0rfdl2o">
         <di:waypoint x="1630" y="235" />
-        <di:waypoint x="1630" y="335" />
+        <di:waypoint x="1630" y="350" />
+        <di:waypoint x="1670" y="350" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1639" y="266" width="81" height="27" />
+          <dc:Bounds x="1539" y="266" width="81" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1xenm35_di" bpmnElement="Flow_1xenm35">
-        <di:waypoint x="1970" y="360" />
-        <di:waypoint x="2030" y="360" />
+        <di:waypoint x="1770" y="360" />
+        <di:waypoint x="1810" y="360" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ixumtp_di" bpmnElement="Flow_0ixumtp">
-        <di:waypoint x="2130" y="360" />
-        <di:waypoint x="2270" y="360" />
-        <di:waypoint x="2270" y="250" />
+        <di:waypoint x="1910" y="360" />
+        <di:waypoint x="1975" y="360" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ozvyhu_di" bpmnElement="Flow_1ozvyhu">
         <di:waypoint x="1655" y="210" />
-        <di:waypoint x="2220" y="210" />
+        <di:waypoint x="2240" y="210" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1698" y="176" width="83" height="27" />
+          <dc:Bounds x="1701" y="176" width="83" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1o9gd21_di" bpmnElement="Flow_1o9gd21">
-        <di:waypoint x="1920" y="460" />
-        <di:waypoint x="1920" y="400" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1vwzwjz_di" bpmnElement="Flow_GA_Not_Enabled">
-        <di:waypoint x="1655" y="360" />
-        <di:waypoint x="1870" y="360" />
+      <bpmndi:BPMNEdge id="Flow_020sxtm_di" bpmnElement="Flow_GA_Not_Enabled">
+        <di:waypoint x="2025" y="360" />
+        <di:waypoint x="2290" y="360" />
+        <di:waypoint x="2290" y="250" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1723" y="342" width="79" height="14" />
+          <dc:Bounds x="2067" y="343" width="79" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1unsrd9_di" bpmnElement="Flow_GA_Enabled">
-        <di:waypoint x="1630" y="385" />
-        <di:waypoint x="1630" y="500" />
-        <di:waypoint x="1700" y="500" />
+      <bpmndi:BPMNEdge id="Flow_0ow1g6s_di" bpmnElement="Flow_0ow1g6s">
+        <di:waypoint x="2000" y="385" />
+        <di:waypoint x="2000" y="490" />
+        <di:waypoint x="2030" y="490" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1640" y="440" width="59" height="14" />
+          <dc:Bounds x="2010" y="423" width="59" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1126ddg_di" bpmnElement="Flow_1126ddg">
-        <di:waypoint x="1800" y="500" />
-        <di:waypoint x="1870" y="500" />
+      <bpmndi:BPMNEdge id="Flow_17716q5_di" bpmnElement="Flow_17716q5">
+        <di:waypoint x="2130" y="490" />
+        <di:waypoint x="2160" y="490" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0n61xqe_di" bpmnElement="Flow_0n61xqe">
+        <di:waypoint x="2260" y="490" />
+        <di:waypoint x="2290" y="490" />
+        <di:waypoint x="2290" y="250" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/CaseProceedsInCasemanTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/CaseProceedsInCasemanTest.java
@@ -275,22 +275,6 @@ class CaseProceedsInCasemanTest extends BpmnBaseTest {
         );
 
         //Dashboard notification
-        ExternalTask claimantGaDashboard = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            claimantGaDashboard,
-            PROCESS_CASE_EVENT,
-            "CREATE_DASHBOARD_NOTIFICATION_APPLICATION_PROCEED_OFFLINE_CLAIMANT",
-            "claimantLipApplicationOfflineDashboardNotification"
-        );
-
-        ExternalTask defendantGaDashboard = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            defendantGaDashboard,
-            PROCESS_CASE_EVENT,
-            "CREATE_DASHBOARD_NOTIFICATION_APPLICATION_PROCEED_OFFLINE_DEFENDANT",
-            "defendantLipApplicationOfflineDashboardNotification"
-        );
-
         respondentNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
         assertCompleteExternalTask(
                 respondentNotification,
@@ -305,6 +289,22 @@ class CaseProceedsInCasemanTest extends BpmnBaseTest {
                 PROCESS_CASE_EVENT,
                 "CREATE_DEFENDANT_DASHBOARD_NOTIFICATION_FOR_CASE_PROCEED_OFFLINE",
                 "GenerateDefendantDashboardNotificationCaseProceedOffline"
+        );
+
+        ExternalTask claimantGaDashboard = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            claimantGaDashboard,
+            PROCESS_CASE_EVENT,
+            "CREATE_DASHBOARD_NOTIFICATION_APPLICATION_PROCEED_OFFLINE_CLAIMANT",
+            "claimantLipApplicationOfflineDashboardNotification"
+        );
+
+        ExternalTask defendantGaDashboard = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            defendantGaDashboard,
+            PROCESS_CASE_EVENT,
+            "CREATE_DASHBOARD_NOTIFICATION_APPLICATION_PROCEED_OFFLINE_DEFENDANT",
+            "defendantLipApplicationOfflineDashboardNotification"
         );
 
         //end business process


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-15835


### Change description ###
 Swap the position of main case dashboard notification tasks because As the case moves offline "Dashboard notification for claimant1/defendant" task handler deletes all the notifications associated with the case which in turn deletes the GA application moved offline notification too.

Old Camunda 
![image](https://github.com/user-attachments/assets/2d579843-e42b-4ede-a477-f1c6fa75dfdb)

New Camunda
![image](https://github.com/user-attachments/assets/befdcf4e-6793-4906-ae28-10dcff4b38fa)



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
