### PR TITLE
CIV-16638 Added new event to trigger main case when varyJudgement app…

### DIFF
--- a/src/main/resources/camunda/respondent_response_general_application.bpmn
+++ b/src/main/resources/camunda/respondent_response_general_application.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_038vuuf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.7.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_038vuuf" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.5.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
   <bpmn:message id="Message_0yl8iuc" name="RESPOND_TO_APPLICATION" />
   <bpmn:collaboration id="RespondentResponseGeneralApplication">
     <bpmn:extensionElements />
@@ -39,9 +39,6 @@
       <bpmn:outgoing>Flow_0702sw7</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_0702sw7" sourceRef="GenerateDraftDocumentId" targetRef="AddDraftDocToMainCaseID" />
-    <bpmn:endEvent id="Event_0ii7uzg">
-      <bpmn:incoming>Flow_0n6ts4r</bpmn:incoming>
-    </bpmn:endEvent>
     <bpmn:serviceTask id="AddDraftDocToMainCaseID" name="Add Draft Document to Parent Case" camunda:type="external" camunda:topic="updateFromGACaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
@@ -52,14 +49,6 @@
       <bpmn:outgoing>Flow_15ok91n</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_15ok91n" sourceRef="AddDraftDocToMainCaseID" targetRef="WaitCivilDraftDocumentUpdatedId" />
-    <bpmn:sequenceFlow id="Flow_1k494rv" sourceRef="WaitCivilDraftDocumentUpdatedId" targetRef="Activity_0eo8p2p" />
-    <bpmn:callActivity id="Activity_0eo8p2p" name="End Business Process" calledElement="GA_EndBusinessProcess">
-      <bpmn:extensionElements>
-        <camunda:in variables="all" />
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1k494rv</bpmn:incoming>
-      <bpmn:outgoing>Flow_0n6ts4r</bpmn:outgoing>
-    </bpmn:callActivity>
     <bpmn:serviceTask id="WaitCivilDraftDocumentUpdatedId" name="Wait Civil Draft Document Updated" camunda:type="external" camunda:topic="WAIT_CIVIL_DOC_UPDATED_GASPEC">
       <bpmn:extensionElements>
         <camunda:inputOutput>
@@ -67,13 +56,46 @@
         </camunda:inputOutput>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_15ok91n</bpmn:incoming>
-      <bpmn:outgoing>Flow_1k494rv</bpmn:outgoing>
+      <bpmn:outgoing>Flow_06bp4tw</bpmn:outgoing>
     </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_0ii7uzg">
+      <bpmn:incoming>Flow_0n6ts4r</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="Activity_0eo8p2p" name="End Business Process" calledElement="GA_EndBusinessProcess">
+      <bpmn:extensionElements>
+        <camunda:in variables="all" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_124c8qk</bpmn:incoming>
+      <bpmn:incoming>Flow_0uphbrm</bpmn:incoming>
+      <bpmn:outgoing>Flow_0n6ts4r</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_124c8qk" sourceRef="TriggerMainCaseToMoveOfflineId" targetRef="Activity_0eo8p2p" />
+    <bpmn:sequenceFlow id="Flow_0uphbrm" name="No" sourceRef="Gateway_1nn6ht5" targetRef="Activity_0eo8p2p">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${(empty flowFlags.VARY_JUDGE_GA_BY_RESP || !flowFlags.VARY_JUDGE_GA_BY_RESP)}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_06bp4tw" sourceRef="WaitCivilDraftDocumentUpdatedId" targetRef="Gateway_1nn6ht5" />
+    <bpmn:serviceTask id="TriggerMainCaseToMoveOfflineId" name="Trigger Parent Case to move offline" camunda:type="external" camunda:topic="processGaCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">TRIGGER_MAIN_CASE_FROM_GA</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1i0lk9v</bpmn:incoming>
+      <bpmn:outgoing>Flow_124c8qk</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:exclusiveGateway id="Gateway_1nn6ht5" name="IsVaryJudgementAppMovedOffline ?">
+      <bpmn:incoming>Flow_06bp4tw</bpmn:incoming>
+      <bpmn:outgoing>Flow_0uphbrm</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1i0lk9v</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1i0lk9v" name="Yes" sourceRef="Gateway_1nn6ht5" targetRef="TriggerMainCaseToMoveOfflineId">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${(!empty flowFlags.VARY_JUDGE_GA_BY_RESP &amp;&amp; flowFlags.VARY_JUDGE_GA_BY_RESP)}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="RespondentResponseGeneralApplication">
       <bpmndi:BPMNShape id="Participant_11shrki_di" bpmnElement="Participant_11shrki" isHorizontal="true">
-        <dc:Bounds x="160" y="80" width="1210" height="350" />
+        <dc:Bounds x="160" y="80" width="1380" height="360" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_19ttrus_di" bpmnElement="Event_19ttrus">
@@ -92,19 +114,29 @@
         <dc:Bounds x="490" y="208" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0ii7uzg_di" bpmnElement="Event_0ii7uzg">
-        <dc:Bounds x="1212" y="230" width="36" height="36" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1cajp65" bpmnElement="AddDraftDocToMainCaseID">
         <dc:Bounds x="670" y="208" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0eo8p2p_di" bpmnElement="Activity_0eo8p2p">
-        <dc:Bounds x="1040" y="208" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0stc1rq" bpmnElement="WaitCivilDraftDocumentUpdatedId">
         <dc:Bounds x="850" y="210" width="100" height="80" />
         <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ii7uzg_di" bpmnElement="Event_0ii7uzg">
+        <dc:Bounds x="1422" y="230" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0eo8p2p_di" bpmnElement="Activity_0eo8p2p">
+        <dc:Bounds x="1250" y="208" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0hpx5j8" bpmnElement="TriggerMainCaseToMoveOfflineId">
+        <dc:Bounds x="1100" y="208" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1nn6ht5_di" bpmnElement="Gateway_1nn6ht5" isMarkerVisible="true">
+        <dc:Bounds x="995" y="225" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="984" y="282" width="86" height="40" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1r5gva6_di" bpmnElement="Event_1r5gva6">
         <dc:Bounds x="322" y="190" width="36" height="36" />
@@ -121,8 +153,8 @@
         <di:waypoint x="290" y="248" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0n6ts4r_di" bpmnElement="Flow_0n6ts4r">
-        <di:waypoint x="1140" y="248" />
-        <di:waypoint x="1212" y="248" />
+        <di:waypoint x="1350" y="248" />
+        <di:waypoint x="1422" y="248" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0gk750v_di" bpmnElement="Flow_0gk750v">
         <di:waypoint x="390" y="248" />
@@ -136,9 +168,29 @@
         <di:waypoint x="770" y="250" />
         <di:waypoint x="850" y="250" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1k494rv_di" bpmnElement="Flow_1k494rv">
+      <bpmndi:BPMNEdge id="Flow_124c8qk_di" bpmnElement="Flow_124c8qk">
+        <di:waypoint x="1200" y="248" />
+        <di:waypoint x="1250" y="248" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uphbrm_di" bpmnElement="Flow_0uphbrm">
+        <di:waypoint x="1020" y="225" />
+        <di:waypoint x="1020" y="160" />
+        <di:waypoint x="1310" y="160" />
+        <di:waypoint x="1310" y="208" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1158" y="142" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06bp4tw_di" bpmnElement="Flow_06bp4tw">
         <di:waypoint x="950" y="250" />
-        <di:waypoint x="1040" y="250" />
+        <di:waypoint x="995" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1i0lk9v_di" bpmnElement="Flow_1i0lk9v">
+        <di:waypoint x="1044" y="249" />
+        <di:waypoint x="1100" y="248" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1064" y="231" width="18" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
… by resp

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-16638
https://tools.hmcts.net/jira/browse/CIV-16640

### Change description ###

The judgment journey that succeeds a decision made on an application to vary judgment has been descoped from judgments online, and therefore, there is no journey available to keep this application type journey online. The scope of this ticket is to trigger the work allocation to take the case offline in this scenario. This covers defendant LiP and defendant LRs making applications to vary judgment - the WA should be triggered at the point the claimant responds (either LR or LiP).

The decisions has been made to take the main claim and application (plus any other applications on the case) offline in this instance.

The scope of this ticket is to enable the following:

Vary judgment is submitted by defendant (LR or LiP)
The WA to the judge to make a decision needs to be suppressed
WA sent to caseworker to take main case offline
Work allocation task needs to contain meaningful text to accurately display description - static text
Notifications are handled in [CIV-16640](https://tools.hmcts.net/jira/browse/CIV-16640)

Scope applies to both with consent and with notice applications - and includes LR v LR; LiP v LiP; LR v LiP and LiP v LR.

![image](https://github.com/user-attachments/assets/88591f6d-e752-4e86-845d-c7829f1ca031)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
