### PR TITLE
DTSCCI-2000 and DTSCCI-1883 Refactor claimant response and claimant response spec so that it notifies all parties in the same events

### DIFF
--- a/src/main/resources/camunda/claimant_response.bpmn
+++ b/src/main/resources/camunda/claimant_response.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_18h9iji" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.1">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_18h9iji" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.28.0">
   <bpmn:process id="CLAIMANT_RESPONSE_PROCESS_ID" name="Claimant Response Process" isExecutable="true" camunda:historyTimeToLive="P90D">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_0g2t112</bpmn:outgoing>
@@ -26,7 +26,7 @@
       <bpmn:incoming>Flow_1hi1wxo</bpmn:incoming>
       <bpmn:incoming>Flow_0hc82e2</bpmn:incoming>
       <bpmn:incoming>Flow_0mzdxwg</bpmn:incoming>
-      <bpmn:outgoing>Flow_18p0npf</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0ucxas6</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:callActivity id="Activity_0gt1863" name="Start Business Process" calledElement="StartBusinessProcess">
       <bpmn:extensionElements>
@@ -67,89 +67,26 @@
       <bpmn:incoming>Flow_FULL_DEFENCE_NOT_PROCEED</bpmn:incoming>
       <bpmn:outgoing>Flow_0qm1yp0</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:serviceTask id="ClaimantConfirmsToProceedNotifyRespondentSolicitor1" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+    <bpmn:serviceTask id="ClaimantConfirmsToProceedNotify" name="Notify parties claimant confirms to proceed" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_TO_PROCEED</camunda:inputParameter>
+          <camunda:inputParameter name="caseEvent">NOTIFY_EVENT</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1if3psp</bpmn:incoming>
-      <bpmn:incoming>Flow_1my8wd4</bpmn:incoming>
+      <bpmn:incoming>Flow_0ucxas6</bpmn:incoming>
       <bpmn:outgoing>Flow_1omrvfy</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1omrvfy" sourceRef="ClaimantConfirmsToProceedNotifyRespondentSolicitor1" targetRef="Gateway_1izgizk" />
-    <bpmn:serviceTask id="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+    <bpmn:sequenceFlow id="Flow_1omrvfy" sourceRef="ClaimantConfirmsToProceedNotify" targetRef="Gateway_0aseqi2" />
+    <bpmn:serviceTask id="ClaimantResponseConfirmsNotToProceedNotify" name="Notify parties claimant confirms not to proceed" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED</camunda:inputParameter>
+          <camunda:inputParameter name="caseEvent">NOTIFY_EVENT</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_10gl6cs</bpmn:incoming>
       <bpmn:incoming>Flow_16dgwpu</bpmn:incoming>
-      <bpmn:outgoing>Flow_1hdxw94</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1gnykhx</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1hdxw94" sourceRef="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1" targetRef="Gateway_12s3fic" />
-    <bpmn:serviceTask id="ClaimantConfirmsToProceedNotifyApplicantSolicitor1CC" name="Notify applicant solicitor 1 (CC)" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_TO_PROCEED_CC</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1e0ozen</bpmn:incoming>
-      <bpmn:incoming>Flow_05kjspo</bpmn:incoming>
-      <bpmn:outgoing>Flow_1kz0xra</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:serviceTask id="ClaimantConfirmsNotToProceedNotifyApplicantSolicitor1CC" name="Notify applicant solicitor 1 (CC)" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED_CC</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0b0so42</bpmn:incoming>
-      <bpmn:incoming>Flow_17nnxrn</bpmn:incoming>
-      <bpmn:outgoing>Flow_0fqn57l</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0fqn57l" sourceRef="ClaimantConfirmsNotToProceedNotifyApplicantSolicitor1CC" targetRef="NotifyRoboticsOnCaseHandedOffline" />
-    <bpmn:exclusiveGateway id="Gateway_1izgizk" default="Flow_1e0ozen">
-      <bpmn:incoming>Flow_1omrvfy</bpmn:incoming>
-      <bpmn:outgoing>Flow_1e0ozen</bpmn:outgoing>
-      <bpmn:outgoing>Flow_0e2144a</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_1e0ozen" sourceRef="Gateway_1izgizk" targetRef="ClaimantConfirmsToProceedNotifyApplicantSolicitor1CC" />
-    <bpmn:serviceTask id="ClaimantConfirmsToProceedNotifyRespondentSolicitor2" name="Notify respondent solicitor 2" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR2_FOR_CLAIMANT_CONFIRMS_TO_PROCEED</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0e2144a</bpmn:incoming>
-      <bpmn:outgoing>Flow_05kjspo</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0e2144a" sourceRef="Gateway_1izgizk" targetRef="ClaimantConfirmsToProceedNotifyRespondentSolicitor2">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.TWO_RESPONDENT_REPRESENTATIVES &amp;&amp; flowFlags.TWO_RESPONDENT_REPRESENTATIVES}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_05kjspo" sourceRef="ClaimantConfirmsToProceedNotifyRespondentSolicitor2" targetRef="ClaimantConfirmsToProceedNotifyApplicantSolicitor1CC" />
-    <bpmn:exclusiveGateway id="Gateway_12s3fic">
-      <bpmn:incoming>Flow_1hdxw94</bpmn:incoming>
-      <bpmn:outgoing>Flow_0b0so42</bpmn:outgoing>
-      <bpmn:outgoing>Flow_095m2os</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_0b0so42" sourceRef="Gateway_12s3fic" targetRef="ClaimantConfirmsNotToProceedNotifyApplicantSolicitor1CC">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.ONE_RESPONDENT_REPRESENTATIVE &amp;&amp; flowFlags.ONE_RESPONDENT_REPRESENTATIVE}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor2" name="Notify respondent solicitor 2" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR2_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_095m2os</bpmn:incoming>
-      <bpmn:outgoing>Flow_17nnxrn</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_095m2os" sourceRef="Gateway_12s3fic" targetRef="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor2">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.TWO_RESPONDENT_REPRESENTATIVES &amp;&amp; flowFlags.TWO_RESPONDENT_REPRESENTATIVES}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_17nnxrn" sourceRef="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor2" targetRef="ClaimantConfirmsNotToProceedNotifyApplicantSolicitor1CC" />
     <bpmn:serviceTask id="JudicialReferral" name="Proceed to judicial referral (Response to defence)" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
@@ -199,10 +136,10 @@
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_0pl9ize" sourceRef="UpdateGeneralApplicationStatus" targetRef="UpdateClaimWithApplicationStatus" />
     <bpmn:sequenceFlow id="Flow_0qm1yp0" sourceRef="ProceedOfflineForResponseToDefence" targetRef="Gateway_1qftb2n" />
-    <bpmn:sequenceFlow id="Flow_10gl6cs" name="General Application Disabled" sourceRef="Gateway_1qftb2n" targetRef="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1">
+    <bpmn:sequenceFlow id="Flow_10gl6cs" name="General Application Disabled" sourceRef="Gateway_1qftb2n" targetRef="ClaimantResponseConfirmsNotToProceedNotify">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${empty flowFlags.GENERAL_APPLICATION_ENABLED || !flowFlags.GENERAL_APPLICATION_ENABLED}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_16dgwpu" sourceRef="UpdateClaimWithApplicationStatus" targetRef="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1" />
+    <bpmn:sequenceFlow id="Flow_16dgwpu" sourceRef="UpdateClaimWithApplicationStatus" targetRef="ClaimantResponseConfirmsNotToProceedNotify" />
     <bpmn:exclusiveGateway id="Gateway_1pc8agd">
       <bpmn:incoming>Flow_1v0mmcy</bpmn:incoming>
       <bpmn:outgoing>Flow_1hi1wxo</bpmn:outgoing>
@@ -231,72 +168,19 @@
           <camunda:inputParameter name="caseEvent">NOTIFY_RPA_ON_CASE_HANDED_OFFLINE</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0fqn57l</bpmn:incoming>
       <bpmn:incoming>Flow_1w9msw7</bpmn:incoming>
+      <bpmn:incoming>Flow_1gnykhx</bpmn:incoming>
       <bpmn:outgoing>Flow_17evp7q</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_17evp7q" sourceRef="NotifyRoboticsOnCaseHandedOffline" targetRef="Activity_1cweuly" />
-    <bpmn:sequenceFlow id="Flow_1kz0xra" sourceRef="ClaimantConfirmsToProceedNotifyApplicantSolicitor1CC" targetRef="Gateway_0aseqi2" />
     <bpmn:exclusiveGateway id="Gateway_0aseqi2">
-      <bpmn:incoming>Flow_1kz0xra</bpmn:incoming>
-      <bpmn:incoming>Flow_07ua8xi</bpmn:incoming>
+      <bpmn:incoming>Flow_1omrvfy</bpmn:incoming>
       <bpmn:outgoing>Flow_1h1gnhq</bpmn:outgoing>
       <bpmn:outgoing>Flow_19roh9l</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_1h1gnhq" sourceRef="Gateway_0aseqi2" targetRef="NotifyRoboticsOnContinuousFeed">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${empty flowFlags.IS_MULTI_TRACK}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:exclusiveGateway id="Gateway_0ivdn1l">
-      <bpmn:incoming>Flow_18p0npf</bpmn:incoming>
-      <bpmn:outgoing>Flow_1if3psp</bpmn:outgoing>
-      <bpmn:outgoing>Flow_0joy5iw</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_18p0npf" sourceRef="ClaimantResponseGenerateDirectionsQuestionnaire" targetRef="Gateway_0ivdn1l" />
-    <bpmn:sequenceFlow id="Flow_1if3psp" sourceRef="Gateway_0ivdn1l" targetRef="ClaimantConfirmsToProceedNotifyRespondentSolicitor1">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${empty flowFlags.IS_MULTI_TRACK}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ClaimantConfirmsToProceedNotifyRespondentSolicitor1Multitrack" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_RES_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_TO_PROCEED_MULTITRACK</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1ox1r0k</bpmn:incoming>
-      <bpmn:outgoing>Flow_1ocoaw0</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:exclusiveGateway id="Gateway_02rr4m0">
-      <bpmn:incoming>Flow_1ocoaw0</bpmn:incoming>
-      <bpmn:outgoing>Flow_17zmdjb</bpmn:outgoing>
-      <bpmn:outgoing>Flow_1qewnk9</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
-    <bpmn:serviceTask id="ClaimantConfirmsToProceedNotifyRespondentSolicitor2Multitrack" name="Notify respondent solicitor 2" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_RES_SOLICITOR2_FOR_CLAIMANT_CONFIRMS_TO_PROCEED_MULTITRACK</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1qewnk9</bpmn:incoming>
-      <bpmn:outgoing>Flow_15x0e7z</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:serviceTask id="ClaimantConfirmsToProceedNotifyApplicantSolicitor1CCMultitrack" name="Notify applicant solicitor 1 (CC)" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_APP_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_TO_PROCEED_CC_MULTITRACK</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_17zmdjb</bpmn:incoming>
-      <bpmn:incoming>Flow_15x0e7z</bpmn:incoming>
-      <bpmn:outgoing>Flow_07ua8xi</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1ocoaw0" sourceRef="ClaimantConfirmsToProceedNotifyRespondentSolicitor1Multitrack" targetRef="Gateway_02rr4m0" />
-    <bpmn:sequenceFlow id="Flow_17zmdjb" sourceRef="Gateway_02rr4m0" targetRef="ClaimantConfirmsToProceedNotifyApplicantSolicitor1CCMultitrack">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.ONE_RESPONDENT_REPRESENTATIVE &amp;&amp; flowFlags.ONE_RESPONDENT_REPRESENTATIVE}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1qewnk9" sourceRef="Gateway_02rr4m0" targetRef="ClaimantConfirmsToProceedNotifyRespondentSolicitor2Multitrack">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.TWO_RESPONDENT_REPRESENTATIVES &amp;&amp; flowFlags.TWO_RESPONDENT_REPRESENTATIVES}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_15x0e7z" sourceRef="ClaimantConfirmsToProceedNotifyRespondentSolicitor2Multitrack" targetRef="ClaimantConfirmsToProceedNotifyApplicantSolicitor1CCMultitrack" />
-    <bpmn:sequenceFlow id="Flow_07ua8xi" sourceRef="ClaimantConfirmsToProceedNotifyApplicantSolicitor1CCMultitrack" targetRef="Gateway_0aseqi2" />
     <bpmn:serviceTask id="ProceedOfflineForResponseToDefenceMultitrack" name="Proceed offline (Response to defence)" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
@@ -321,20 +205,6 @@
     <bpmn:sequenceFlow id="Flow_0929kvp" name="Minti enabled" sourceRef="Gateway_0vyo2fr" targetRef="JudicialReferral">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.MINTI_ENABLED &amp;&amp; flowFlags.MINTI_ENABLED}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:exclusiveGateway id="Gateway_1aiuvpa">
-      <bpmn:incoming>Flow_0joy5iw</bpmn:incoming>
-      <bpmn:outgoing>Flow_1ox1r0k</bpmn:outgoing>
-      <bpmn:outgoing>Flow_1my8wd4</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_0joy5iw" name="Multi track claim" sourceRef="Gateway_0ivdn1l" targetRef="Gateway_1aiuvpa">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.IS_MULTI_TRACK}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1ox1r0k" name="Minti not enabled" sourceRef="Gateway_1aiuvpa" targetRef="ClaimantConfirmsToProceedNotifyRespondentSolicitor1Multitrack">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.MINTI_ENABLED &amp;&amp; !flowFlags.MINTI_ENABLED}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1my8wd4" name="Minti Enabled" sourceRef="Gateway_1aiuvpa" targetRef="ClaimantConfirmsToProceedNotifyRespondentSolicitor1">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.MINTI_ENABLED &amp;&amp; flowFlags.MINTI_ENABLED}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="Gateway_0uziwiq">
       <bpmn:incoming>Flow_19roh9l</bpmn:incoming>
       <bpmn:outgoing>Flow_1w9msw7</bpmn:outgoing>
@@ -349,411 +219,249 @@
     <bpmn:sequenceFlow id="Flow_0ruzefo" name="Minti enabled" sourceRef="Gateway_0uziwiq" targetRef="NotifyRoboticsOnContinuousFeed">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.MINTI_ENABLED &amp;&amp; flowFlags.MINTI_ENABLED}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:textAnnotation id="TextAnnotation_1o3q1xa">
-      <bpmn:text>2 Respondent representatives</bpmn:text>
-    </bpmn:textAnnotation>
-    <bpmn:association id="Association_1574yb4" sourceRef="Gateway_1izgizk" targetRef="TextAnnotation_1o3q1xa" />
-    <bpmn:textAnnotation id="TextAnnotation_10tbeub">
-      <bpmn:text>1 Respondent representative</bpmn:text>
-    </bpmn:textAnnotation>
-    <bpmn:association id="Association_0058pjs" sourceRef="Gateway_1izgizk" targetRef="TextAnnotation_10tbeub" />
-    <bpmn:textAnnotation id="TextAnnotation_12lq3or">
-      <bpmn:text>2 Respondent representatives</bpmn:text>
-    </bpmn:textAnnotation>
-    <bpmn:association id="Association_0k37ha8" sourceRef="Gateway_12s3fic" targetRef="TextAnnotation_12lq3or" />
-    <bpmn:textAnnotation id="TextAnnotation_0zax79s">
-      <bpmn:text>1 Respondent representative</bpmn:text>
-    </bpmn:textAnnotation>
+    <bpmn:sequenceFlow id="Flow_1gnykhx" sourceRef="ClaimantResponseConfirmsNotToProceedNotify" targetRef="NotifyRoboticsOnCaseHandedOffline" />
+    <bpmn:sequenceFlow id="Flow_0ucxas6" sourceRef="ClaimantResponseGenerateDirectionsQuestionnaire" targetRef="ClaimantConfirmsToProceedNotify" />
   </bpmn:process>
   <bpmn:message id="Message_0ttrrz3" name="CLAIMANT_RESPONSE" />
   <bpmn:error id="Error_1alq6sw" name="StartBusinessAbort" errorCode="ABORT" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="CLAIMANT_RESPONSE_PROCESS_ID">
-      <bpmndi:BPMNEdge id="Flow_0929kvp_di" bpmnElement="Flow_0929kvp">
-        <di:waypoint x="570" y="325" />
-        <di:waypoint x="570" y="360" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="497" y="331" width="66" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_03zkicc_di" bpmnElement="Flow_03zkicc">
-        <di:waypoint x="595" y="300" />
-        <di:waypoint x="680" y="300" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="588" y="310" width="84" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1sqruq3_di" bpmnElement="Flow_1sqruq3">
-        <di:waypoint x="460" y="565" />
-        <di:waypoint x="460" y="300" />
-        <di:waypoint x="545" y="300" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="440" y="273" width="80" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0mzdxwg_di" bpmnElement="Flow_0mzdxwg">
-        <di:waypoint x="780" y="300" />
-        <di:waypoint x="910" y="300" />
-        <di:waypoint x="910" y="370" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_07ua8xi_di" bpmnElement="Flow_07ua8xi">
-        <di:waypoint x="1550" y="190" />
-        <di:waypoint x="1600" y="190" />
-        <di:waypoint x="1600" y="385" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_15x0e7z_di" bpmnElement="Flow_15x0e7z">
-        <di:waypoint x="1410" y="80" />
-        <di:waypoint x="1430" y="80" />
-        <di:waypoint x="1430" y="190" />
-        <di:waypoint x="1450" y="190" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1qewnk9_di" bpmnElement="Flow_1qewnk9">
-        <di:waypoint x="1260" y="165" />
-        <di:waypoint x="1260" y="80" />
-        <di:waypoint x="1310" y="80" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_17zmdjb_di" bpmnElement="Flow_17zmdjb">
-        <di:waypoint x="1285" y="190" />
-        <di:waypoint x="1450" y="190" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1ocoaw0_di" bpmnElement="Flow_1ocoaw0">
-        <di:waypoint x="1189" y="190" />
-        <di:waypoint x="1235" y="190" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1if3psp_di" bpmnElement="Flow_1if3psp">
-        <di:waypoint x="1045" y="410" />
-        <di:waypoint x="1089" y="410" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_18p0npf_di" bpmnElement="Flow_18p0npf">
-        <di:waypoint x="970" y="410" />
-        <di:waypoint x="995" y="410" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1h1gnhq_di" bpmnElement="Flow_1h1gnhq">
-        <di:waypoint x="1625" y="410" />
-        <di:waypoint x="1660" y="410" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1kz0xra_di" bpmnElement="Flow_1kz0xra">
-        <di:waypoint x="1550" y="410" />
-        <di:waypoint x="1575" y="410" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_17evp7q_di" bpmnElement="Flow_17evp7q">
-        <di:waypoint x="1640" y="590" />
-        <di:waypoint x="1770" y="590" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0hc82e2_di" bpmnElement="Flow_0hc82e2">
-        <di:waypoint x="849" y="500" />
-        <di:waypoint x="920" y="500" />
-        <di:waypoint x="920" y="450" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0wuppw6_di" bpmnElement="Flow_0wuppw6">
-        <di:waypoint x="790" y="425" />
-        <di:waypoint x="790" y="460" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="734" y="420" width="53" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1hi1wxo_di" bpmnElement="Flow_1hi1wxo">
-        <di:waypoint x="815" y="400" />
-        <di:waypoint x="870" y="400" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="817" y="350" width="53" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1v0mmcy_di" bpmnElement="Flow_1v0mmcy">
-        <di:waypoint x="620" y="400" />
-        <di:waypoint x="765" y="400" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_16dgwpu_di" bpmnElement="Flow_16dgwpu">
-        <di:waypoint x="1033" y="790" />
-        <di:waypoint x="1033" y="710" />
-        <di:waypoint x="1010" y="710" />
-        <di:waypoint x="1010" y="630" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_10gl6cs_di" bpmnElement="Flow_10gl6cs">
-        <di:waypoint x="945" y="680" />
-        <di:waypoint x="1010" y="680" />
-        <di:waypoint x="1010" y="630" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="943" y="680" width="53" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0qm1yp0_di" bpmnElement="Flow_0qm1yp0">
-        <di:waypoint x="810" y="630" />
-        <di:waypoint x="810" y="680" />
-        <di:waypoint x="895" y="680" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0pl9ize_di" bpmnElement="Flow_0pl9ize">
-        <di:waypoint x="939" y="830" />
-        <di:waypoint x="983" y="830" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_145j0ir_di" bpmnElement="Flow_145j0ir">
-        <di:waypoint x="920" y="705" />
-        <di:waypoint x="920" y="748" />
-        <di:waypoint x="799" y="748" />
-        <di:waypoint x="799" y="830" />
-        <di:waypoint x="839" y="830" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="863" y="700" width="53" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_14lf0re_di" bpmnElement="Flow_14lf0re">
-        <di:waypoint x="1760" y="420" />
-        <di:waypoint x="1820" y="420" />
-        <di:waypoint x="1820" y="550" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_17nnxrn_di" bpmnElement="Flow_17nnxrn">
-        <di:waypoint x="1230" y="520" />
-        <di:waypoint x="1260" y="520" />
-        <di:waypoint x="1260" y="590" />
-        <di:waypoint x="1280" y="590" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_095m2os_di" bpmnElement="Flow_095m2os">
-        <di:waypoint x="1110" y="565" />
-        <di:waypoint x="1110" y="520" />
-        <di:waypoint x="1130" y="520" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0b0so42_di" bpmnElement="Flow_0b0so42">
-        <di:waypoint x="1135" y="590" />
-        <di:waypoint x="1280" y="590" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_05kjspo_di" bpmnElement="Flow_05kjspo">
-        <di:waypoint x="1340" y="370" />
-        <di:waypoint x="1340" y="410" />
-        <di:waypoint x="1450" y="410" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0e2144a_di" bpmnElement="Flow_0e2144a">
-        <di:waypoint x="1240" y="385" />
-        <di:waypoint x="1240" y="330" />
-        <di:waypoint x="1290" y="330" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1e0ozen_di" bpmnElement="Flow_1e0ozen">
-        <di:waypoint x="1265" y="410" />
-        <di:waypoint x="1450" y="410" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0fqn57l_di" bpmnElement="Flow_0fqn57l">
-        <di:waypoint x="1380" y="590" />
-        <di:waypoint x="1540" y="590" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1hdxw94_di" bpmnElement="Flow_1hdxw94">
-        <di:waypoint x="1060" y="590" />
-        <di:waypoint x="1085" y="590" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1omrvfy_di" bpmnElement="Flow_1omrvfy">
-        <di:waypoint x="1189" y="410" />
-        <di:waypoint x="1215" y="410" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0fz18qx_di" bpmnElement="Flow_FULL_DEFENCE_PROCEED">
-        <di:waypoint x="460" y="565" />
-        <di:waypoint x="460" y="400" />
-        <di:waypoint x="520" y="400" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="366" y="528" width="90" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_185dsos_di" bpmnElement="Flow_FULL_DEFENCE_NOT_PROCEED">
-        <di:waypoint x="485" y="590" />
-        <di:waypoint x="760" y="590" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="562" y="606" width="90" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_19mft34_di" bpmnElement="Flow_19mft34">
-        <di:waypoint x="370" y="590" />
-        <di:waypoint x="435" y="590" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0g2t112_di" bpmnElement="Flow_0g2t112">
-        <di:waypoint x="188" y="593" />
-        <di:waypoint x="270" y="593" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_13dgz5v_di" bpmnElement="Flow_13dgz5v">
-        <di:waypoint x="320" y="532" />
-        <di:waypoint x="320" y="495" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0tgwl48_di" bpmnElement="Flow_0tgwl48">
-        <di:waypoint x="1870" y="590" />
-        <di:waypoint x="1962" y="590" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0joy5iw_di" bpmnElement="Flow_0joy5iw">
-        <di:waypoint x="1020" y="385" />
-        <di:waypoint x="1020" y="335" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="930" y="343" width="80" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1ox1r0k_di" bpmnElement="Flow_1ox1r0k">
-        <di:waypoint x="1020" y="285" />
-        <di:waypoint x="1020" y="190" />
-        <di:waypoint x="1089" y="190" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="991" y="163" width="84" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1my8wd4_di" bpmnElement="Flow_1my8wd4">
-        <di:waypoint x="1045" y="310" />
-        <di:waypoint x="1100" y="310" />
-        <di:waypoint x="1100" y="370" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1040" y="292" width="67" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_19roh9l_di" bpmnElement="Flow_19roh9l">
-        <di:waypoint x="1600" y="435" />
-        <di:waypoint x="1600" y="475" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1520" y="452" width="80" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1w9msw7_di" bpmnElement="Flow_1w9msw7">
-        <di:waypoint x="1600" y="525" />
-        <di:waypoint x="1598" y="550" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1508" y="520" width="84" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ruzefo_di" bpmnElement="Flow_0ruzefo">
-        <di:waypoint x="1625" y="500" />
-        <di:waypoint x="1710" y="500" />
-        <di:waypoint x="1710" y="450" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1635" y="482" width="66" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1diii28_di" bpmnElement="StartEvent_1">
-        <dc:Bounds x="152" y="575" width="36" height="36" />
+        <dc:Bounds x="152" y="395" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_07ek9xj_di" bpmnElement="Event_07ek9xj">
+        <dc:Bounds x="1962" y="392" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_14sbez9_di" bpmnElement="Activity_1cweuly">
+        <dc:Bounds x="1770" y="370" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_05zzi0k_di" bpmnElement="ClaimantResponseGenerateDirectionsQuestionnaire">
-        <dc:Bounds x="870" y="370" width="100" height="80" />
+        <dc:Bounds x="870" y="190" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0gt1863_di" bpmnElement="Activity_0gt1863">
-        <dc:Bounds x="270" y="550" width="100" height="80" />
+        <dc:Bounds x="270" y="370" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0nc34kd_di" bpmnElement="Event_0nc34kd">
-        <dc:Bounds x="302" y="459" width="36" height="36" />
+        <dc:Bounds x="302" y="279" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0p15z9i_di" bpmnElement="Gateway_PROCEED_OR_NOT_PROCEED" isMarkerVisible="true">
-        <dc:Bounds x="435" y="565" width="50" height="50" />
+        <dc:Bounds x="435" y="385" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_028lxzs_di" bpmnElement="ProceedOfflineForResponseToDefence">
-        <dc:Bounds x="760" y="550" width="100" height="80" />
+        <dc:Bounds x="760" y="370" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1c4psp2_di" bpmnElement="ClaimantConfirmsToProceedNotifyRespondentSolicitor1">
-        <dc:Bounds x="1089" y="370" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1up0lu9_di" bpmnElement="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1">
-        <dc:Bounds x="960" y="550" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_13ulnqp_di" bpmnElement="ClaimantConfirmsToProceedNotifyApplicantSolicitor1CC">
-        <dc:Bounds x="1450" y="370" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0f90qs7_di" bpmnElement="ClaimantConfirmsNotToProceedNotifyApplicantSolicitor1CC">
-        <dc:Bounds x="1280" y="550" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1izgizk_di" bpmnElement="Gateway_1izgizk" isMarkerVisible="true">
-        <dc:Bounds x="1215" y="385" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_17u6lyf_di" bpmnElement="ClaimantConfirmsToProceedNotifyRespondentSolicitor2">
-        <dc:Bounds x="1290" y="290" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_12s3fic_di" bpmnElement="Gateway_12s3fic" isMarkerVisible="true">
-        <dc:Bounds x="1085" y="565" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0z32kt8_di" bpmnElement="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor2">
-        <dc:Bounds x="1130" y="480" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_1c4psp2_di" bpmnElement="ClaimantConfirmsToProceedNotify">
+        <dc:Bounds x="1089" y="190" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1xj9809" bpmnElement="JudicialReferral">
-        <dc:Bounds x="520" y="360" width="100" height="80" />
+        <dc:Bounds x="520" y="180" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0fzi0zq_di" bpmnElement="NotifyRoboticsOnContinuousFeed">
-        <dc:Bounds x="1660" y="370" width="100" height="80" />
+        <dc:Bounds x="1660" y="190" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1qftb2n_di" bpmnElement="Gateway_1qftb2n" isMarkerVisible="true">
-        <dc:Bounds x="895" y="655" width="50" height="50" />
+        <dc:Bounds x="895" y="475" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UpdateGeneralApplicationStatus_di" bpmnElement="UpdateGeneralApplicationStatus">
-        <dc:Bounds x="839" y="790" width="100" height="80" />
+        <dc:Bounds x="839" y="610" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UpdateClaimWithApplicationStatus_di" bpmnElement="UpdateClaimWithApplicationStatus">
-        <dc:Bounds x="983" y="790" width="100" height="80" />
+        <dc:Bounds x="983" y="610" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1pc8agd_di" bpmnElement="Gateway_1pc8agd" isMarkerVisible="true">
-        <dc:Bounds x="765" y="375" width="50" height="50" />
+        <dc:Bounds x="765" y="195" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1ctrg77" bpmnElement="TriggerAndUpdateGenAppLocation">
-        <dc:Bounds x="749" y="460" width="100" height="80" />
+        <dc:Bounds x="749" y="280" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_15wxp1o_di" bpmnElement="NotifyRoboticsOnCaseHandedOffline">
-        <dc:Bounds x="1540" y="550" width="100" height="80" />
+        <dc:Bounds x="1540" y="370" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0aseqi2_di" bpmnElement="Gateway_0aseqi2" isMarkerVisible="true">
-        <dc:Bounds x="1575" y="385" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0ivdn1l_di" bpmnElement="Gateway_0ivdn1l" isMarkerVisible="true">
-        <dc:Bounds x="995" y="385" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1m78e34_di" bpmnElement="ClaimantConfirmsToProceedNotifyRespondentSolicitor1Multitrack">
-        <dc:Bounds x="1089" y="150" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_02rr4m0_di" bpmnElement="Gateway_02rr4m0" isMarkerVisible="true">
-        <dc:Bounds x="1235" y="165" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1jayrgp_di" bpmnElement="ClaimantConfirmsToProceedNotifyRespondentSolicitor2Multitrack">
-        <dc:Bounds x="1310" y="40" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1jeplus_di" bpmnElement="ClaimantConfirmsToProceedNotifyApplicantSolicitor1CCMultitrack">
-        <dc:Bounds x="1450" y="150" width="100" height="80" />
-        <bpmndi:BPMNLabel />
+        <dc:Bounds x="1575" y="205" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_065ckij" bpmnElement="ProceedOfflineForResponseToDefenceMultitrack">
-        <dc:Bounds x="680" y="260" width="100" height="80" />
+        <dc:Bounds x="680" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0vyo2fr_di" bpmnElement="Gateway_0vyo2fr" isMarkerVisible="true">
-        <dc:Bounds x="545" y="275" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="TextAnnotation_1o3q1xa_di" bpmnElement="TextAnnotation_1o3q1xa">
-        <dc:Bounds x="1110" y="315" width="110" height="45" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="TextAnnotation_10tbeub_di" bpmnElement="TextAnnotation_10tbeub">
-        <dc:Bounds x="1320" y="430" width="100" height="40" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="TextAnnotation_12lq3or_di" bpmnElement="TextAnnotation_12lq3or">
-        <dc:Bounds x="1000" y="480" width="100" height="40" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="TextAnnotation_0zax79s_di" bpmnElement="TextAnnotation_0zax79s">
-        <dc:Bounds x="1130" y="610" width="100" height="40" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1aiuvpa_di" bpmnElement="Gateway_1aiuvpa" isMarkerVisible="true">
-        <dc:Bounds x="995" y="285" width="50" height="50" />
+        <dc:Bounds x="545" y="95" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0uziwiq_di" bpmnElement="Gateway_0uziwiq" isMarkerVisible="true">
-        <dc:Bounds x="1575" y="475" width="50" height="50" />
+        <dc:Bounds x="1575" y="295" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_07ek9xj_di" bpmnElement="Event_07ek9xj">
-        <dc:Bounds x="1962" y="572" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_14sbez9_di" bpmnElement="Activity_1cweuly">
-        <dc:Bounds x="1770" y="550" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_1up0lu9_di" bpmnElement="ClaimantResponseConfirmsNotToProceedNotify">
+        <dc:Bounds x="1000" y="370" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1p3emre_di" bpmnElement="Event_1p3emre">
-        <dc:Bounds x="302" y="532" width="36" height="36" />
+        <dc:Bounds x="302" y="352" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="337" y="513" width="27" height="14" />
+          <dc:Bounds x="337" y="333" width="27" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Association_1574yb4_di" bpmnElement="Association_1574yb4">
-        <di:waypoint x="1231" y="394" />
-        <di:waypoint x="1215" y="360" />
+      <bpmndi:BPMNEdge id="Flow_0tgwl48_di" bpmnElement="Flow_0tgwl48">
+        <di:waypoint x="1870" y="410" />
+        <di:waypoint x="1962" y="410" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0058pjs_di" bpmnElement="Association_0058pjs">
-        <di:waypoint x="1260" y="415" />
-        <di:waypoint x="1320" y="432" />
+      <bpmndi:BPMNEdge id="Flow_13dgz5v_di" bpmnElement="Flow_13dgz5v">
+        <di:waypoint x="320" y="352" />
+        <di:waypoint x="320" y="315" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0k37ha8_di" bpmnElement="Association_0k37ha8">
-        <di:waypoint x="1101" y="574" />
-        <di:waypoint x="1065" y="520" />
+      <bpmndi:BPMNEdge id="Flow_0g2t112_di" bpmnElement="Flow_0g2t112">
+        <di:waypoint x="188" y="413" />
+        <di:waypoint x="270" y="413" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19mft34_di" bpmnElement="Flow_19mft34">
+        <di:waypoint x="370" y="410" />
+        <di:waypoint x="435" y="410" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_185dsos_di" bpmnElement="Flow_FULL_DEFENCE_NOT_PROCEED">
+        <di:waypoint x="485" y="410" />
+        <di:waypoint x="760" y="410" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="562" y="426" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0fz18qx_di" bpmnElement="Flow_FULL_DEFENCE_PROCEED">
+        <di:waypoint x="460" y="385" />
+        <di:waypoint x="460" y="220" />
+        <di:waypoint x="520" y="220" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="366" y="348" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1omrvfy_di" bpmnElement="Flow_1omrvfy">
+        <di:waypoint x="1189" y="230" />
+        <di:waypoint x="1575" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14lf0re_di" bpmnElement="Flow_14lf0re">
+        <di:waypoint x="1760" y="240" />
+        <di:waypoint x="1820" y="240" />
+        <di:waypoint x="1820" y="370" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_145j0ir_di" bpmnElement="Flow_145j0ir">
+        <di:waypoint x="920" y="525" />
+        <di:waypoint x="920" y="568" />
+        <di:waypoint x="799" y="568" />
+        <di:waypoint x="799" y="650" />
+        <di:waypoint x="839" y="650" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="863" y="520" width="54" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0pl9ize_di" bpmnElement="Flow_0pl9ize">
+        <di:waypoint x="939" y="650" />
+        <di:waypoint x="983" y="650" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qm1yp0_di" bpmnElement="Flow_0qm1yp0">
+        <di:waypoint x="810" y="450" />
+        <di:waypoint x="810" y="500" />
+        <di:waypoint x="895" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10gl6cs_di" bpmnElement="Flow_10gl6cs">
+        <di:waypoint x="945" y="500" />
+        <di:waypoint x="1050" y="500" />
+        <di:waypoint x="1050" y="450" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="958" y="500" width="54" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16dgwpu_di" bpmnElement="Flow_16dgwpu">
+        <di:waypoint x="1033" y="610" />
+        <di:waypoint x="1033" y="530" />
+        <di:waypoint x="1050" y="530" />
+        <di:waypoint x="1050" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1v0mmcy_di" bpmnElement="Flow_1v0mmcy">
+        <di:waypoint x="620" y="220" />
+        <di:waypoint x="765" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hi1wxo_di" bpmnElement="Flow_1hi1wxo">
+        <di:waypoint x="815" y="220" />
+        <di:waypoint x="870" y="220" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="817" y="170" width="54" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0wuppw6_di" bpmnElement="Flow_0wuppw6">
+        <di:waypoint x="790" y="245" />
+        <di:waypoint x="790" y="280" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="734" y="240" width="54" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0hc82e2_di" bpmnElement="Flow_0hc82e2">
+        <di:waypoint x="849" y="320" />
+        <di:waypoint x="920" y="320" />
+        <di:waypoint x="920" y="270" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_17evp7q_di" bpmnElement="Flow_17evp7q">
+        <di:waypoint x="1640" y="410" />
+        <di:waypoint x="1770" y="410" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1h1gnhq_di" bpmnElement="Flow_1h1gnhq">
+        <di:waypoint x="1625" y="230" />
+        <di:waypoint x="1660" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mzdxwg_di" bpmnElement="Flow_0mzdxwg">
+        <di:waypoint x="780" y="120" />
+        <di:waypoint x="910" y="120" />
+        <di:waypoint x="910" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1sqruq3_di" bpmnElement="Flow_1sqruq3">
+        <di:waypoint x="460" y="385" />
+        <di:waypoint x="460" y="120" />
+        <di:waypoint x="545" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="441" y="93" width="79" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_03zkicc_di" bpmnElement="Flow_03zkicc">
+        <di:waypoint x="595" y="120" />
+        <di:waypoint x="680" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="588" y="130" width="84" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0929kvp_di" bpmnElement="Flow_0929kvp">
+        <di:waypoint x="570" y="145" />
+        <di:waypoint x="570" y="180" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="497" y="151" width="66" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19roh9l_di" bpmnElement="Flow_19roh9l">
+        <di:waypoint x="1600" y="255" />
+        <di:waypoint x="1600" y="295" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1521" y="272" width="79" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1w9msw7_di" bpmnElement="Flow_1w9msw7">
+        <di:waypoint x="1600" y="345" />
+        <di:waypoint x="1598" y="370" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1508" y="340" width="84" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ruzefo_di" bpmnElement="Flow_0ruzefo">
+        <di:waypoint x="1625" y="320" />
+        <di:waypoint x="1710" y="320" />
+        <di:waypoint x="1710" y="270" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1635" y="302" width="66" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gnykhx_di" bpmnElement="Flow_1gnykhx">
+        <di:waypoint x="1100" y="410" />
+        <di:waypoint x="1540" y="410" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ucxas6_di" bpmnElement="Flow_0ucxas6">
+        <di:waypoint x="970" y="230" />
+        <di:waypoint x="1089" y="230" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/camunda/claimant_response_spec.bpmn
+++ b/src/main/resources/camunda/claimant_response_spec.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_18h9iji" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_18h9iji" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.28.0">
   <bpmn:process id="CLAIMANT_RESPONSE_PROCESS_ID_SPEC" name="Claimant response process spec" isExecutable="true" camunda:historyTimeToLive="P90D">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_0g2t112</bpmn:outgoing>
@@ -44,14 +44,14 @@
           <camunda:inputParameter name="caseEvent">NOTIFY_RPA_ON_CASE_HANDED_OFFLINE</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0fqn57l</bpmn:incoming>
       <bpmn:incoming>Flow_0evghcx</bpmn:incoming>
       <bpmn:incoming>Flow_0u83asq</bpmn:incoming>
       <bpmn:incoming>Flow_00f0sau</bpmn:incoming>
-      <bpmn:incoming>Flow_1m8na44</bpmn:incoming>
+      <bpmn:incoming>Flow_0qtr7fz</bpmn:incoming>
+      <bpmn:incoming>Flow_0vpn38g</bpmn:incoming>
       <bpmn:outgoing>Flow_12hrz4u</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1hr7okm" sourceRef="ClaimantResponseGenerateDirectionsQuestionnaire" targetRef="ClaimantConfirmsToProceedNotifyRespondentSolicitor1" />
+    <bpmn:sequenceFlow id="Flow_1hr7okm" sourceRef="ClaimantResponseGenerateDirectionsQuestionnaire" targetRef="ClaimantConfirmsToProceedNotify" />
     <bpmn:exclusiveGateway id="Gateway_PROCEED_OR_NOT_PROCEED">
       <bpmn:incoming>Flow_19mft34</bpmn:incoming>
       <bpmn:outgoing>Flow_FULL_DEFENCE_NOT_PROCEED</bpmn:outgoing>
@@ -71,94 +71,16 @@
     <bpmn:sequenceFlow id="Flow_FULL_DEFENCE_PROCEED" name="Applicant confirms to proceed (full/part admit)" sourceRef="Gateway_PROCEED_OR_NOT_PROCEED" targetRef="Activity_0izac4m">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.FULL_ADMIT_PROCEED" || flowState == "MAIN.PART_ADMIT_PROCEED"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ClaimantConfirmsToProceedNotifyRespondentSolicitor1" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+    <bpmn:serviceTask id="ClaimantConfirmsToProceedNotify" name="Notify parties claimant confirms to proceed" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_TO_PROCEED</camunda:inputParameter>
+          <camunda:inputParameter name="caseEvent">NOTIFY_EVENT</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1hr7okm</bpmn:incoming>
-      <bpmn:outgoing>Flow_1omrvfy</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1omrvfy" sourceRef="ClaimantConfirmsToProceedNotifyRespondentSolicitor1" targetRef="Gateway_1izgizk" />
-    <bpmn:serviceTask id="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0wq9d0n</bpmn:incoming>
-      <bpmn:incoming>Flow_0qgx8dw</bpmn:incoming>
-      <bpmn:outgoing>Flow_1hdxw94</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1hdxw94" sourceRef="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1" targetRef="Gateway_12s3fic" />
-    <bpmn:serviceTask id="ClaimantConfirmsToProceedNotifyApplicantSolicitor1CC" name="Notify applicant solicitor 1 (CC)" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_TO_PROCEED_CC</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1e0ozen</bpmn:incoming>
-      <bpmn:incoming>Flow_1grniv8</bpmn:incoming>
-      <bpmn:incoming>Flow_05kjspo</bpmn:incoming>
       <bpmn:outgoing>Flow_02s7jvc</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_02s7jvc" sourceRef="ClaimantConfirmsToProceedNotifyApplicantSolicitor1CC" targetRef="Gateway_1scpjza" />
-    <bpmn:serviceTask id="ClaimantConfirmsNotToProceedNotifyApplicantSolicitor1CC" name="Notify applicant solicitor 1 (CC)" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED_CC</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0b0so42</bpmn:incoming>
-      <bpmn:incoming>Flow_17nnxrn</bpmn:incoming>
-      <bpmn:outgoing>Flow_0fqn57l</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0fqn57l" sourceRef="ClaimantConfirmsNotToProceedNotifyApplicantSolicitor1CC" targetRef="NotifyRoboticsOnCaseHandedOffline" />
-    <bpmn:exclusiveGateway id="Gateway_1izgizk">
-      <bpmn:incoming>Flow_1omrvfy</bpmn:incoming>
-      <bpmn:outgoing>Flow_1e0ozen</bpmn:outgoing>
-      <bpmn:outgoing>Flow_0e2144a</bpmn:outgoing>
-      <bpmn:outgoing>Flow_1grniv8</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_1e0ozen" sourceRef="Gateway_1izgizk" targetRef="ClaimantConfirmsToProceedNotifyApplicantSolicitor1CC">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.ONE_RESPONDENT_REPRESENTATIVE &amp;&amp; flowFlags.ONE_RESPONDENT_REPRESENTATIVE}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ClaimantConfirmsToProceedNotifyRespondentSolicitor2" name="Notify respondent solicitor 2" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR2_FOR_CLAIMANT_CONFIRMS_TO_PROCEED</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0e2144a</bpmn:incoming>
-      <bpmn:outgoing>Flow_05kjspo</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0e2144a" sourceRef="Gateway_1izgizk" targetRef="ClaimantConfirmsToProceedNotifyRespondentSolicitor2">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.TWO_RESPONDENT_REPRESENTATIVES &amp;&amp; flowFlags.TWO_RESPONDENT_REPRESENTATIVES}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1grniv8" sourceRef="Gateway_1izgizk" targetRef="ClaimantConfirmsToProceedNotifyApplicantSolicitor1CC" />
-    <bpmn:sequenceFlow id="Flow_05kjspo" sourceRef="ClaimantConfirmsToProceedNotifyRespondentSolicitor2" targetRef="ClaimantConfirmsToProceedNotifyApplicantSolicitor1CC" />
-    <bpmn:exclusiveGateway id="Gateway_12s3fic">
-      <bpmn:incoming>Flow_1hdxw94</bpmn:incoming>
-      <bpmn:outgoing>Flow_0b0so42</bpmn:outgoing>
-      <bpmn:outgoing>Flow_095m2os</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_0b0so42" sourceRef="Gateway_12s3fic" targetRef="ClaimantConfirmsNotToProceedNotifyApplicantSolicitor1CC">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.ONE_RESPONDENT_REPRESENTATIVE &amp;&amp; flowFlags.ONE_RESPONDENT_REPRESENTATIVE}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor2" name="Notify respondent solicitor 2" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR2_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_095m2os</bpmn:incoming>
-      <bpmn:outgoing>Flow_17nnxrn</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_095m2os" sourceRef="Gateway_12s3fic" targetRef="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor2">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.TWO_RESPONDENT_REPRESENTATIVES &amp;&amp; flowFlags.TWO_RESPONDENT_REPRESENTATIVES}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_17nnxrn" sourceRef="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor2" targetRef="ClaimantConfirmsNotToProceedNotifyApplicantSolicitor1CC" />
+    <bpmn:sequenceFlow id="Flow_02s7jvc" sourceRef="ClaimantConfirmsToProceedNotify" targetRef="Gateway_1scpjza" />
     <bpmn:serviceTask id="JudicialReferral" name="Proceed to judicial referral (Response to defence)" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
@@ -282,10 +204,6 @@
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.GENERAL_APPLICATION_ENABLED &amp;&amp; flowFlags.GENERAL_APPLICATION_ENABLED}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_0jda7bj" sourceRef="UpdateGeneralApplicationStatus" targetRef="UpdateClaimWithApplicationStatus" />
-    <bpmn:sequenceFlow id="Flow_0wq9d0n" sourceRef="UpdateClaimWithApplicationStatus" targetRef="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1" />
-    <bpmn:sequenceFlow id="Flow_0qgx8dw" name="General Application Enabled" sourceRef="Gateway_0oh5bmw" targetRef="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${empty flowFlags.GENERAL_APPLICATION_ENABLED || !flowFlags.GENERAL_APPLICATION_ENABLED}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
     <bpmn:serviceTask id="ClaimantAgreedRepaymentNotifyRespondent1" name="Notify respondent 1" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
@@ -344,53 +262,33 @@
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${empty flowFlags.UNREPRESENTED_DEFENDANT_ONE  || (!empty flowFlags.UNREPRESENTED_DEFENDANT_ONE &amp;&amp; !flowFlags.UNREPRESENTED_DEFENDANT_ONE)}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_1ld7h4t" sourceRef="ProceedOfflineForResponseToDefence" targetRef="Gateway_04v5dxt" />
-    <bpmn:sequenceFlow id="Flow_ADMIT_PART_REJECT_REPAYMENT" name="Applicant reject repayment plan (full/part admit)" sourceRef="Gateway_PROCEED_OR_NOT_PROCEED" targetRef="ClaimantDisAgreeRepaymentPlanNotifyApplicant">
+    <bpmn:sequenceFlow id="Flow_ADMIT_PART_REJECT_REPAYMENT" name="Applicant reject repayment plan (full/part admit)" sourceRef="Gateway_PROCEED_OR_NOT_PROCEED" targetRef="ClaimantResponseNotAgreedRepaymentNotify">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.FULL_ADMIT_REJECT_REPAYMENT" || flowState == "MAIN.PART_ADMIT_REJECT_REPAYMENT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ClaimantDisAgreeRepaymentPlanNotifyApplicant" name="Notify applicant solicitor 1 (CC)" camunda:type="external" camunda:topic="processCaseEvent">
+    <bpmn:serviceTask id="ClaimantResponseNotAgreedRepaymentNotify" name="Notify parties claimant repayment not agreed" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_CLAIMANT_FOR_RESPONDENT1_REJECT_REPAYMENT</camunda:inputParameter>
+          <camunda:inputParameter name="caseEvent">NOTIFY_EVENT</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_ADMIT_PART_REJECT_REPAYMENT</bpmn:incoming>
       <bpmn:outgoing>Flow_0qtr7fz</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0qtr7fz" sourceRef="ClaimantDisAgreeRepaymentPlanNotifyApplicant" targetRef="ClaimantDisAgreedRepaymentPlanNotifyLip" />
-    <bpmn:serviceTask id="ClaimantDisAgreedRepaymentPlanNotifyLip" name="Notify respondent 1" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_LIP_DEFENDANT_REJECT_REPAYMENT</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0qtr7fz</bpmn:incoming>
-      <bpmn:outgoing>Flow_1m8na44</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1m8na44" sourceRef="ClaimantDisAgreedRepaymentPlanNotifyLip" targetRef="NotifyRoboticsOnCaseHandedOffline" />
-    <bpmn:sequenceFlow id="IN_MEDIATION_FLOW" name="In Mediation" sourceRef="Gateway_PROCEED_OR_NOT_PROCEED" targetRef="ClaimantDefendantAgreedMediationNotifyApplicant">
+    <bpmn:sequenceFlow id="Flow_0qtr7fz" sourceRef="ClaimantResponseNotAgreedRepaymentNotify" targetRef="NotifyRoboticsOnCaseHandedOffline" />
+    <bpmn:sequenceFlow id="IN_MEDIATION_FLOW" name="In Mediation" sourceRef="Gateway_PROCEED_OR_NOT_PROCEED" targetRef="ClaimantDefendantAgreedMediationNotify">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.IN_MEDIATION"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_ADMIT_PART_SETTLE_CLAIM" name="Applicant confirms settle claim (part admit)" sourceRef="Gateway_PROCEED_OR_NOT_PROCEED" targetRef="ClaimantAgreedSettledPartAdmitNotifyLip">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.PART_ADMIT_AGREE_SETTLE" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0mfqkdm" sourceRef="ClaimantDefendantAgreedMediationNotifyApplicant" targetRef="ClaimantDefendantAgreedMediationNotifyRespondent" />
-    <bpmn:serviceTask id="ClaimantDefendantAgreedMediationNotifyApplicant" name="Notify applicant 1" camunda:type="external" camunda:topic="processCaseEvent">
+    <bpmn:serviceTask id="ClaimantDefendantAgreedMediationNotify" name="Notify parties claimant agreed mediation" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_APPLICANT_MEDIATION_AGREEMENT</camunda:inputParameter>
+          <camunda:inputParameter name="caseEvent">NOTIFY_EVENT</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
       <bpmn:incoming>IN_MEDIATION_FLOW</bpmn:incoming>
-      <bpmn:outgoing>Flow_0mfqkdm</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:serviceTask id="ClaimantDefendantAgreedMediationNotifyRespondent" name="Notify respondent 1" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_MEDIATION_AGREEMENT</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0mfqkdm</bpmn:incoming>
-      <bpmn:outgoing>Flow_0ulnzgo</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0zesk9e</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:serviceTask id="ClaimantAgreedSettledPartAdmitNotifyLip" name="Notify respondent 1" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
@@ -430,8 +328,7 @@
           <camunda:inputParameter name="caseEvent">GENERATE_DIRECTIONS_QUESTIONNAIRE</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1v7bhvv</bpmn:incoming>
-      <bpmn:incoming>Flow_1svlviw</bpmn:incoming>
+      <bpmn:incoming>Flow_0zesk9e</bpmn:incoming>
       <bpmn:outgoing>Flow_0rus79u</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_0rus79u" sourceRef="ClaimantGenerateDQMeditation" targetRef="NotifyRoboticsOnContinuousFeed" />
@@ -446,28 +343,6 @@
     <bpmn:sequenceFlow id="Flow_Sdo_Enabled" name="Sdo on" sourceRef="Gateway_Sdo_Enabled" targetRef="JudicialReferral">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.SDO_ENABLED &amp;&amp; flowFlags.SDO_ENABLED}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:exclusiveGateway id="Gateway_0gjh55q">
-      <bpmn:incoming>Flow_0ulnzgo</bpmn:incoming>
-      <bpmn:outgoing>Flow_1v7bhvv</bpmn:outgoing>
-      <bpmn:outgoing>Flow_01lbenj</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_0ulnzgo" sourceRef="ClaimantDefendantAgreedMediationNotifyRespondent" targetRef="Gateway_0gjh55q" />
-    <bpmn:sequenceFlow id="Flow_1v7bhvv" sourceRef="Gateway_0gjh55q" targetRef="ClaimantGenerateDQMeditation">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${empty flowFlags.TWO_RESPONDENT_REPRESENTATIVES}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ClaimantDefendantAgreedMediationNotifyRespondent2" name="Notify respondent 2" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT2_MEDIATION_AGREEMENT</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_01lbenj</bpmn:incoming>
-      <bpmn:outgoing>Flow_1svlviw</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_01lbenj" sourceRef="Gateway_0gjh55q" targetRef="ClaimantDefendantAgreedMediationNotifyRespondent2">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.TWO_RESPONDENT_REPRESENTATIVES &amp;&amp; flowFlags.TWO_RESPONDENT_REPRESENTATIVES}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1svlviw" sourceRef="ClaimantDefendantAgreedMediationNotifyRespondent2" targetRef="ClaimantGenerateDQMeditation" />
     <bpmn:callActivity id="Activity_0xp7fjj" name="End Business Process" calledElement="EndBusinessProcess">
       <bpmn:extensionElements>
         <camunda:in variables="all" />
@@ -562,33 +437,26 @@
     <bpmn:sequenceFlow id="Flow_0fq9s3w" name="Applicant confirms not to proceed part admit(pay immediately) and JO online Enabled" sourceRef="Gateway_PROCEED_OR_NOT_PROCEED" targetRef="Gateway_1wy38h2">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.JO_ONLINE_LIVE_ENABLED &amp;&amp; flowFlags.JO_ONLINE_LIVE_ENABLED &amp;&amp; flowState == "MAIN.PART_ADMIT_PAY_IMMEDIATELY"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:textAnnotation id="TextAnnotation_1o3q1xa">
-      <bpmn:text>2 Respondent representatives</bpmn:text>
-    </bpmn:textAnnotation>
-    <bpmn:association id="Association_1574yb4" sourceRef="Gateway_1izgizk" targetRef="TextAnnotation_1o3q1xa" />
-    <bpmn:textAnnotation id="TextAnnotation_10tbeub">
-      <bpmn:text>1 Respondent representative</bpmn:text>
-    </bpmn:textAnnotation>
-    <bpmn:association id="Association_0058pjs" sourceRef="Gateway_1izgizk" targetRef="TextAnnotation_10tbeub" />
-    <bpmn:textAnnotation id="TextAnnotation_12lq3or">
-      <bpmn:text>2 Respondent representatives</bpmn:text>
-    </bpmn:textAnnotation>
-    <bpmn:association id="Association_0k37ha8" sourceRef="Gateway_12s3fic" targetRef="TextAnnotation_12lq3or" />
-    <bpmn:textAnnotation id="TextAnnotation_0zax79s">
-      <bpmn:text>1 Respondent representative</bpmn:text>
-    </bpmn:textAnnotation>
+    <bpmn:sequenceFlow id="Flow_0zesk9e" sourceRef="ClaimantDefendantAgreedMediationNotify" targetRef="ClaimantGenerateDQMeditation" />
+    <bpmn:serviceTask id="ClaimantResponseConfirmsNotToProceedNotify" name="Notify parites claimant confirms not to proceed" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_EVENT</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0qgx8dw</bpmn:incoming>
+      <bpmn:incoming>Flow_0wq9d0n</bpmn:incoming>
+      <bpmn:outgoing>Flow_0vpn38g</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0vpn38g" sourceRef="ClaimantResponseConfirmsNotToProceedNotify" targetRef="NotifyRoboticsOnCaseHandedOffline" />
+    <bpmn:sequenceFlow id="Flow_0qgx8dw" name="General Application Enabled" sourceRef="Gateway_0oh5bmw" targetRef="ClaimantResponseConfirmsNotToProceedNotify">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${empty flowFlags.GENERAL_APPLICATION_ENABLED || !flowFlags.GENERAL_APPLICATION_ENABLED}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0wq9d0n" sourceRef="UpdateClaimWithApplicationStatus" targetRef="ClaimantResponseConfirmsNotToProceedNotify" />
     <bpmn:textAnnotation id="TextAnnotation_0qgljrk">
       <bpmn:text>LR or LIP respondent?</bpmn:text>
     </bpmn:textAnnotation>
     <bpmn:association id="Association_1oen8zm" sourceRef="Gateway_04v5dxt" targetRef="TextAnnotation_0qgljrk" />
-    <bpmn:textAnnotation id="TextAnnotation_1x03rdz">
-      <bpmn:text>2 Respondent representatives</bpmn:text>
-    </bpmn:textAnnotation>
-    <bpmn:association id="Association_18itsoq" sourceRef="Gateway_0gjh55q" targetRef="TextAnnotation_1x03rdz" />
-    <bpmn:textAnnotation id="TextAnnotation_1l5q3bl">
-      <bpmn:text>1 Respondent representative</bpmn:text>
-    </bpmn:textAnnotation>
-    <bpmn:association id="Association_0yrrfj5" sourceRef="Gateway_0gjh55q" targetRef="TextAnnotation_1l5q3bl" />
   </bpmn:process>
   <bpmn:message id="Message_0ttrrz3" name="CLAIMANT_RESPONSE_SPEC" />
   <bpmn:error id="Error_1alq6sw" name="StartBusinessAbort" errorCode="ABORT" />
@@ -615,29 +483,13 @@
       <bpmndi:BPMNShape id="Gateway_0p15z9i_di" bpmnElement="Gateway_PROCEED_OR_NOT_PROCEED" isMarkerVisible="true">
         <dc:Bounds x="405" y="495" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1c4psp2_di" bpmnElement="ClaimantConfirmsToProceedNotifyRespondentSolicitor1">
-        <dc:Bounds x="760" y="210" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1up0lu9_di" bpmnElement="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1">
+      <bpmndi:BPMNShape id="Activity_1up0lu9_di" bpmnElement="ClaimantResponseConfirmsNotToProceedNotify">
         <dc:Bounds x="950" y="690" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_13ulnqp_di" bpmnElement="ClaimantConfirmsToProceedNotifyApplicantSolicitor1CC">
+      <bpmndi:BPMNShape id="Activity_13ulnqp_di" bpmnElement="ClaimantConfirmsToProceedNotify">
         <dc:Bounds x="1080" y="210" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0f90qs7_di" bpmnElement="ClaimantConfirmsNotToProceedNotifyApplicantSolicitor1CC">
-        <dc:Bounds x="1270" y="690" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1izgizk_di" bpmnElement="Gateway_1izgizk" isMarkerVisible="true">
-        <dc:Bounds x="885" y="225" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_17u6lyf_di" bpmnElement="ClaimantConfirmsToProceedNotifyRespondentSolicitor2">
-        <dc:Bounds x="940" y="130" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_12s3fic_di" bpmnElement="Gateway_12s3fic" isMarkerVisible="true">
-        <dc:Bounds x="1075" y="705" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0z32kt8_di" bpmnElement="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor2">
-        <dc:Bounds x="1120" y="620" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1xj9809" bpmnElement="JudicialReferral">
         <dc:Bounds x="380" y="80" width="100" height="80" />
@@ -693,20 +545,12 @@
       <bpmndi:BPMNShape id="Gateway_04v5dxt_di" bpmnElement="Gateway_04v5dxt" isMarkerVisible="true">
         <dc:Bounds x="725" y="705" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_13aq65z" bpmnElement="ClaimantDisAgreeRepaymentPlanNotifyApplicant">
+      <bpmndi:BPMNShape id="BPMNShape_13aq65z" bpmnElement="ClaimantResponseNotAgreedRepaymentNotify">
         <dc:Bounds x="680" y="1290" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1i7id8i" bpmnElement="ClaimantDisAgreedRepaymentPlanNotifyLip">
-        <dc:Bounds x="969" y="1290" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0sje9kz_di" bpmnElement="ClaimantDefendantAgreedMediationNotifyApplicant">
+      <bpmndi:BPMNShape id="Activity_0sje9kz_di" bpmnElement="ClaimantDefendantAgreedMediationNotify">
         <dc:Bounds x="680" y="1390" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0hmfm8y_di" bpmnElement="ClaimantDefendantAgreedMediationNotifyRespondent">
-        <dc:Bounds x="960" y="1390" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0oip6xh" bpmnElement="ClaimantAgreedSettledPartAdmitNotifyLip">
@@ -724,12 +568,6 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0qca0w5_di" bpmnElement="Gateway_Sdo_Enabled" isMarkerVisible="true">
         <dc:Bounds x="405" y="225" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0gjh55q_di" bpmnElement="Gateway_0gjh55q" isMarkerVisible="true">
-        <dc:Bounds x="1185" y="1425" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_03c1gvw_di" bpmnElement="ClaimantDefendantAgreedMediationNotifyRespondent2">
-        <dc:Bounds x="1270" y="1350" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1lmfxkd" bpmnElement="Activity_0xp7fjj">
         <dc:Bounds x="2280" y="483" width="100" height="80" />
@@ -757,27 +595,9 @@
         <dc:Bounds x="2100" y="630" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="TextAnnotation_1o3q1xa_di" bpmnElement="TextAnnotation_1o3q1xa">
-        <dc:Bounds x="790" y="155" width="110" height="45" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="TextAnnotation_10tbeub_di" bpmnElement="TextAnnotation_10tbeub">
-        <dc:Bounds x="940" y="260" width="100" height="40" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="TextAnnotation_12lq3or_di" bpmnElement="TextAnnotation_12lq3or">
-        <dc:Bounds x="990" y="620" width="100" height="40" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="TextAnnotation_0zax79s_di" bpmnElement="TextAnnotation_0zax79s">
-        <dc:Bounds x="1120" y="750" width="100" height="40" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="TextAnnotation_0qgljrk_di" bpmnElement="TextAnnotation_0qgljrk">
         <dc:Bounds x="700" y="645" width="100" height="39" />
         <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="TextAnnotation_1x03rdz_di" bpmnElement="TextAnnotation_1x03rdz">
-        <dc:Bounds x="1100" y="1365" width="94" height="30" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="TextAnnotation_1l5q3bl_di" bpmnElement="TextAnnotation_1l5q3bl">
-        <dc:Bounds x="1270" y="1460" width="100" height="41" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1p3emre_di" bpmnElement="Event_1p3emre">
         <dc:Bounds x="222" y="462" width="36" height="36" />
@@ -799,7 +619,7 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1hr7okm_di" bpmnElement="Flow_1hr7okm">
         <di:waypoint x="710" y="250" />
-        <di:waypoint x="760" y="250" />
+        <di:waypoint x="1080" y="250" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_185dsos_di" bpmnElement="Flow_FULL_DEFENCE_NOT_PROCEED">
         <di:waypoint x="430" y="545" />
@@ -816,57 +636,10 @@
           <dc:Bounds x="484" y="536" width="90" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1omrvfy_di" bpmnElement="Flow_1omrvfy">
-        <di:waypoint x="860" y="250" />
-        <di:waypoint x="885" y="250" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1hdxw94_di" bpmnElement="Flow_1hdxw94">
-        <di:waypoint x="1050" y="730" />
-        <di:waypoint x="1075" y="730" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_02s7jvc_di" bpmnElement="Flow_02s7jvc">
         <di:waypoint x="1180" y="250" />
         <di:waypoint x="1440" y="250" />
         <di:waypoint x="1440" y="305" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0fqn57l_di" bpmnElement="Flow_0fqn57l">
-        <di:waypoint x="1370" y="730" />
-        <di:waypoint x="1440" y="730" />
-        <di:waypoint x="1440" y="560" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1e0ozen_di" bpmnElement="Flow_1e0ozen">
-        <di:waypoint x="935" y="250" />
-        <di:waypoint x="1080" y="250" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0e2144a_di" bpmnElement="Flow_0e2144a">
-        <di:waypoint x="910" y="225" />
-        <di:waypoint x="910" y="170" />
-        <di:waypoint x="940" y="170" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1grniv8_di" bpmnElement="Flow_1grniv8">
-        <di:waypoint x="935" y="250" />
-        <di:waypoint x="1080" y="250" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_05kjspo_di" bpmnElement="Flow_05kjspo">
-        <di:waypoint x="1040" y="170" />
-        <di:waypoint x="1060" y="170" />
-        <di:waypoint x="1060" y="250" />
-        <di:waypoint x="1080" y="250" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0b0so42_di" bpmnElement="Flow_0b0so42">
-        <di:waypoint x="1125" y="730" />
-        <di:waypoint x="1270" y="730" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_095m2os_di" bpmnElement="Flow_095m2os">
-        <di:waypoint x="1100" y="705" />
-        <di:waypoint x="1100" y="660" />
-        <di:waypoint x="1120" y="660" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_17nnxrn_di" bpmnElement="Flow_17nnxrn">
-        <di:waypoint x="1220" y="660" />
-        <di:waypoint x="1250" y="660" />
-        <di:waypoint x="1250" y="730" />
-        <di:waypoint x="1270" y="730" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ydl2zw_di" bpmnElement="Full_defence_proceed_no_mediation">
         <di:waypoint x="430" y="495" />
@@ -1016,10 +789,6 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0qtr7fz_di" bpmnElement="Flow_0qtr7fz">
         <di:waypoint x="780" y="1330" />
-        <di:waypoint x="969" y="1330" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1m8na44_di" bpmnElement="Flow_1m8na44">
-        <di:waypoint x="1069" y="1330" />
         <di:waypoint x="1440" y="1330" />
         <di:waypoint x="1440" y="560" />
       </bpmndi:BPMNEdge>
@@ -1038,10 +807,6 @@
         <bpmndi:BPMNLabel>
           <dc:Bounds x="435" y="1480" width="90" height="40" />
         </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0mfqkdm_di" bpmnElement="Flow_0mfqkdm">
-        <di:waypoint x="780" y="1430" />
-        <di:waypoint x="960" y="1430" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_15h287v_di" bpmnElement="Flow_Flow_PAY_IMMEDIATELY">
         <di:waypoint x="430" y="545" />
@@ -1079,27 +844,6 @@
         <bpmndi:BPMNLabel>
           <dc:Bounds x="429" y="190" width="35" height="14" />
         </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ulnzgo_di" bpmnElement="Flow_0ulnzgo">
-        <di:waypoint x="1060" y="1430" />
-        <di:waypoint x="1123" y="1430" />
-        <di:waypoint x="1123" y="1450" />
-        <di:waypoint x="1185" y="1450" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1v7bhvv_di" bpmnElement="Flow_1v7bhvv">
-        <di:waypoint x="1235" y="1450" />
-        <di:waypoint x="1420" y="1450" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_01lbenj_di" bpmnElement="Flow_01lbenj">
-        <di:waypoint x="1210" y="1425" />
-        <di:waypoint x="1210" y="1390" />
-        <di:waypoint x="1270" y="1390" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1svlviw_di" bpmnElement="Flow_1svlviw">
-        <di:waypoint x="1370" y="1390" />
-        <di:waypoint x="1395" y="1390" />
-        <di:waypoint x="1395" y="1450" />
-        <di:waypoint x="1420" y="1450" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ico438_di" bpmnElement="Flow_1ico438">
         <di:waypoint x="2380" y="523" />
@@ -1214,29 +958,21 @@
           <dc:Bounds x="435" y="1540" width="90" height="80" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1574yb4_di" bpmnElement="Association_1574yb4">
-        <di:waypoint x="903" y="232" />
-        <di:waypoint x="892" y="200" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0058pjs_di" bpmnElement="Association_0058pjs">
-        <di:waypoint x="929" y="256" />
-        <di:waypoint x="942" y="260" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0k37ha8_di" bpmnElement="Association_0k37ha8">
-        <di:waypoint x="1091" y="714" />
-        <di:waypoint x="1055" y="660" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Association_1oen8zm_di" bpmnElement="Association_1oen8zm">
         <di:waypoint x="750" y="705" />
         <di:waypoint x="750" y="684" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_18itsoq_di" bpmnElement="Association_18itsoq">
-        <di:waypoint x="1196" y="1439" />
-        <di:waypoint x="1139" y="1395" />
+      <bpmndi:BPMNEdge id="Flow_0zesk9e_di" bpmnElement="Flow_0zesk9e">
+        <di:waypoint x="780" y="1430" />
+        <di:waypoint x="1100" y="1430" />
+        <di:waypoint x="1100" y="1450" />
+        <di:waypoint x="1420" y="1450" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_0yrrfj5_di" bpmnElement="Association_0yrrfj5">
-        <di:waypoint x="1230" y="1455" />
-        <di:waypoint x="1270" y="1464" />
+      <bpmndi:BPMNEdge id="Flow_0vpn38g_di" bpmnElement="Flow_0vpn38g">
+        <di:waypoint x="1050" y="730" />
+        <di:waypoint x="1220" y="730" />
+        <di:waypoint x="1220" y="520" />
+        <di:waypoint x="1390" y="520" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/camunda/claimant_response_spec.bpmn
+++ b/src/main/resources/camunda/claimant_response_spec.bpmn
@@ -204,10 +204,10 @@
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.GENERAL_APPLICATION_ENABLED &amp;&amp; flowFlags.GENERAL_APPLICATION_ENABLED}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_0jda7bj" sourceRef="UpdateGeneralApplicationStatus" targetRef="UpdateClaimWithApplicationStatus" />
-    <bpmn:serviceTask id="ClaimantAgreedRepaymentNotifyRespondent1" name="Notify respondent 1" camunda:type="external" camunda:topic="processCaseEvent">
+    <bpmn:serviceTask id="ClaimantResponseAgreedRepaymentNotify" name="Notify respondent 1 claimant agreed repayment" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT1_FOR_CLAIMANT_AGREED_REPAYMENT</camunda:inputParameter>
+          <camunda:inputParameter name="caseEvent">NOTIFY_EVENT</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0qiuirk</bpmn:incoming>
@@ -216,7 +216,7 @@
     <bpmn:sequenceFlow id="Flow_ADMIT_PART_ACCEPT_REPAYMENT" name="Applicant confirms repayment plan (full/part admit)" sourceRef="Gateway_PROCEED_OR_NOT_PROCEED" targetRef="Activity_00lleen">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.FULL_ADMIT_AGREE_REPAYMENT" || flowState == "MAIN.PART_ADMIT_AGREE_REPAYMENT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0u83asq" sourceRef="ClaimantAgreedRepaymentNotifyRespondent1" targetRef="NotifyRoboticsOnCaseHandedOffline" />
+    <bpmn:sequenceFlow id="Flow_0u83asq" sourceRef="ClaimantResponseAgreedRepaymentNotify" targetRef="NotifyRoboticsOnCaseHandedOffline" />
     <bpmn:exclusiveGateway id="Gateway_1pc8agd">
       <bpmn:incoming>Flow_15yahzj</bpmn:incoming>
       <bpmn:incoming>Flow_Sdo_Disabled</bpmn:incoming>
@@ -278,7 +278,7 @@
     <bpmn:sequenceFlow id="IN_MEDIATION_FLOW" name="In Mediation" sourceRef="Gateway_PROCEED_OR_NOT_PROCEED" targetRef="ClaimantDefendantAgreedMediationNotify">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.IN_MEDIATION"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_ADMIT_PART_SETTLE_CLAIM" name="Applicant confirms settle claim (part admit)" sourceRef="Gateway_PROCEED_OR_NOT_PROCEED" targetRef="ClaimantAgreedSettledPartAdmitNotifyLip">
+    <bpmn:sequenceFlow id="Flow_ADMIT_PART_SETTLE_CLAIM" name="Applicant confirms settle claim (part admit)" sourceRef="Gateway_PROCEED_OR_NOT_PROCEED" targetRef="ClaimantResponseAgreedSettledPartAdmitNotify">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.PART_ADMIT_AGREE_SETTLE" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:serviceTask id="ClaimantDefendantAgreedMediationNotify" name="Notify parties claimant agreed mediation" camunda:type="external" camunda:topic="processCaseEvent">
@@ -290,10 +290,10 @@
       <bpmn:incoming>IN_MEDIATION_FLOW</bpmn:incoming>
       <bpmn:outgoing>Flow_0zesk9e</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:serviceTask id="ClaimantAgreedSettledPartAdmitNotifyLip" name="Notify respondent 1" camunda:type="external" camunda:topic="processCaseEvent">
+    <bpmn:serviceTask id="ClaimantResponseAgreedSettledPartAdmitNotify" name="Notify respondent 1 agreed settled part admit" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_LIP_DEFENDANT_PART_ADMIT_CLAIM_SETTLED</camunda:inputParameter>
+          <camunda:inputParameter name="caseEvent">NOTIFY_EVENT</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_ADMIT_PART_SETTLE_CLAIM</bpmn:incoming>
@@ -321,7 +321,7 @@
       <bpmn:incoming>Flow_ADMIT_PART_ACCEPT_REPAYMENT</bpmn:incoming>
       <bpmn:outgoing>Flow_0qiuirk</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0qiuirk" sourceRef="Activity_00lleen" targetRef="ClaimantAgreedRepaymentNotifyRespondent1" />
+    <bpmn:sequenceFlow id="Flow_0qiuirk" sourceRef="Activity_00lleen" targetRef="ClaimantResponseAgreedRepaymentNotify" />
     <bpmn:serviceTask id="ClaimantGenerateDQMeditation" name="Generate DQ" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
@@ -374,7 +374,7 @@
       <bpmn:outgoing>Flow_189q5fx</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_0rg51dv" sourceRef="NotifyRoboticsOnContinuousFeed" targetRef="Gateway_1wy38h2" />
-    <bpmn:sequenceFlow id="Flow_0unqxdq" sourceRef="ClaimantAgreedSettledPartAdmitNotifyLip" targetRef="Gateway_1wy38h2" />
+    <bpmn:sequenceFlow id="Flow_0unqxdq" sourceRef="ClaimantResponseAgreedSettledPartAdmitNotify" targetRef="Gateway_1wy38h2" />
     <bpmn:sequenceFlow id="Flow_189q5fx" sourceRef="Gateway_1wy38h2" targetRef="Gateway_10ndl16" />
     <bpmn:exclusiveGateway id="Gateway_10ndl16">
       <bpmn:incoming>Flow_189q5fx</bpmn:incoming>
@@ -483,10 +483,6 @@
       <bpmndi:BPMNShape id="Gateway_0p15z9i_di" bpmnElement="Gateway_PROCEED_OR_NOT_PROCEED" isMarkerVisible="true">
         <dc:Bounds x="405" y="495" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1up0lu9_di" bpmnElement="ClaimantResponseConfirmsNotToProceedNotify">
-        <dc:Bounds x="950" y="690" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_13ulnqp_di" bpmnElement="ClaimantConfirmsToProceedNotify">
         <dc:Bounds x="1080" y="210" width="100" height="80" />
         <bpmndi:BPMNLabel />
@@ -528,8 +524,9 @@
       <bpmndi:BPMNShape id="UpdateClaimWithApplicationStatus_di" bpmnElement="UpdateClaimWithApplicationStatus">
         <dc:Bounds x="1054" y="920" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1pa6xen_di" bpmnElement="ClaimantAgreedRepaymentNotifyRespondent1">
+      <bpmndi:BPMNShape id="Activity_1pa6xen_di" bpmnElement="ClaimantResponseAgreedRepaymentNotify">
         <dc:Bounds x="969" y="1040" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1pc8agd_di" bpmnElement="Gateway_1pc8agd" isMarkerVisible="true">
         <dc:Bounds x="545" y="225" width="50" height="50" />
@@ -553,7 +550,7 @@
         <dc:Bounds x="680" y="1390" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0oip6xh" bpmnElement="ClaimantAgreedSettledPartAdmitNotifyLip">
+      <bpmndi:BPMNShape id="BPMNShape_0oip6xh" bpmnElement="ClaimantResponseAgreedSettledPartAdmitNotify">
         <dc:Bounds x="680" y="1480" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
@@ -593,6 +590,10 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1ovf9ab_di" bpmnElement="defendantLipApplicationOfflineDashboardNotification">
         <dc:Bounds x="2100" y="630" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1up0lu9_di" bpmnElement="ClaimantResponseConfirmsNotToProceedNotify">
+        <dc:Bounds x="950" y="690" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="TextAnnotation_0qgljrk_di" bpmnElement="TextAnnotation_0qgljrk">
@@ -716,19 +717,6 @@
       <bpmndi:BPMNEdge id="Flow_0jda7bj_di" bpmnElement="Flow_0jda7bj">
         <di:waypoint x="1018" y="960" />
         <di:waypoint x="1054" y="960" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0wq9d0n_di" bpmnElement="Flow_0wq9d0n">
-        <di:waypoint x="1104" y="920" />
-        <di:waypoint x="1104" y="845" />
-        <di:waypoint x="1000" y="845" />
-        <di:waypoint x="1000" y="770" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0qgx8dw_di" bpmnElement="Flow_0qgx8dw">
-        <di:waypoint x="870" y="730" />
-        <di:waypoint x="950" y="730" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="883" y="740" width="54" height="40" />
-        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0isyki3_di" bpmnElement="Flow_ADMIT_PART_ACCEPT_REPAYMENT">
         <di:waypoint x="430" y="545" />
@@ -958,10 +946,6 @@
           <dc:Bounds x="435" y="1540" width="90" height="80" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1oen8zm_di" bpmnElement="Association_1oen8zm">
-        <di:waypoint x="750" y="705" />
-        <di:waypoint x="750" y="684" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0zesk9e_di" bpmnElement="Flow_0zesk9e">
         <di:waypoint x="780" y="1430" />
         <di:waypoint x="1100" y="1430" />
@@ -973,6 +957,23 @@
         <di:waypoint x="1220" y="730" />
         <di:waypoint x="1220" y="520" />
         <di:waypoint x="1390" y="520" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qgx8dw_di" bpmnElement="Flow_0qgx8dw">
+        <di:waypoint x="870" y="730" />
+        <di:waypoint x="950" y="730" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="883" y="740" width="54" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0wq9d0n_di" bpmnElement="Flow_0wq9d0n">
+        <di:waypoint x="1104" y="920" />
+        <di:waypoint x="1104" y="845" />
+        <di:waypoint x="1000" y="845" />
+        <di:waypoint x="1000" y="770" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1oen8zm_di" bpmnElement="Association_1oen8zm">
+        <di:waypoint x="750" y="705" />
+        <di:waypoint x="750" y="684" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/camunda/claimant_response_spec.bpmn
+++ b/src/main/resources/camunda/claimant_response_spec.bpmn
@@ -240,10 +240,10 @@
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.GENERAL_APPLICATION_ENABLED &amp;&amp; flowFlags.GENERAL_APPLICATION_ENABLED}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_19i2yb2" sourceRef="TriggerAndUpdateGenAppLocation" targetRef="ClaimantResponseGenerateDirectionsQuestionnaire" />
-    <bpmn:serviceTask id="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1Lip" name="Notify respondent 1 LIP" camunda:type="external" camunda:topic="processCaseEvent">
+    <bpmn:serviceTask id="ClaimantResponseConfirmsNotToProceedLipNotify" name="Notify respondent 1 LIP" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED_LIP</camunda:inputParameter>
+          <camunda:inputParameter name="caseEvent">NOTIFY_EVENT</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0sizv5e</bpmn:incoming>
@@ -255,7 +255,7 @@
       <bpmn:outgoing>Flow_0sizv5e</bpmn:outgoing>
       <bpmn:outgoing>Flow_0awrvza</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_0sizv5e" sourceRef="Gateway_04v5dxt" targetRef="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1Lip">
+    <bpmn:sequenceFlow id="Flow_0sizv5e" sourceRef="Gateway_04v5dxt" targetRef="ClaimantResponseConfirmsNotToProceedLipNotify">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.UNREPRESENTED_DEFENDANT_ONE &amp;&amp; flowFlags.UNREPRESENTED_DEFENDANT_ONE}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_0awrvza" sourceRef="Gateway_04v5dxt" targetRef="Gateway_0oh5bmw">
@@ -398,10 +398,10 @@
     <bpmn:sequenceFlow id="Flow_08exbes" name="LR or (LIP &#38; CUI R2 disabled)" sourceRef="Gateway_1ogom39" targetRef="ProceedOfflineForResponseToDefence">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${(empty flowFlags.UNREPRESENTED_DEFENDANT_ONE  || (!empty flowFlags.UNREPRESENTED_DEFENDANT_ONE &amp;&amp; !flowFlags.UNREPRESENTED_DEFENDANT_ONE)) || (!empty flowFlags.UNREPRESENTED_DEFENDANT_ONE &amp;&amp; flowFlags.UNREPRESENTED_DEFENDANT_ONE &amp;&amp; (empty flowFlags.DASHBOARD_SERVICE_ENABLED || !flowFlags.DASHBOARD_SERVICE_ENABLED))}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1lj7kn9" name="LiP &#38;  CUI R2 enabled" sourceRef="Gateway_1ogom39" targetRef="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1Lip">
+    <bpmn:sequenceFlow id="Flow_1lj7kn9" name="LiP &#38;  CUI R2 enabled" sourceRef="Gateway_1ogom39" targetRef="ClaimantResponseConfirmsNotToProceedLipNotify">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${(!empty flowFlags.UNREPRESENTED_DEFENDANT_ONE &amp;&amp; flowFlags.UNREPRESENTED_DEFENDANT_ONE) &amp;&amp; (flowState == "MAIN.FULL_DEFENCE_NOT_PROCEED") &amp;&amp; (!empty flowFlags.DASHBOARD_SERVICE_ENABLED &amp;&amp; flowFlags.DASHBOARD_SERVICE_ENABLED)}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1dx6rl0" sourceRef="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1Lip" targetRef="Gateway_1wy38h2" />
+    <bpmn:sequenceFlow id="Flow_1dx6rl0" sourceRef="ClaimantResponseConfirmsNotToProceedLipNotify" targetRef="Gateway_1wy38h2" />
     <bpmn:exclusiveGateway id="Gateway_1jhr7mx">
       <bpmn:incoming>Flow_Flow_PAY_IMMEDIATELY</bpmn:incoming>
       <bpmn:outgoing>Flow_JO_ONLINE_DISABLED</bpmn:outgoing>
@@ -535,7 +535,7 @@
         <dc:Bounds x="530" y="320" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_102sqc0" bpmnElement="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1Lip">
+      <bpmndi:BPMNShape id="BPMNShape_102sqc0" bpmnElement="ClaimantResponseConfirmsNotToProceedLipNotify">
         <dc:Bounds x="700" y="900" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ClaimantResponseSpecTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ClaimantResponseSpecTest.java
@@ -707,7 +707,6 @@ class ClaimantResponseSpecTest extends BpmnBaseTest {
             variables
         );
 
-
         //complete the notification to respondent
         ExternalTask notifyRespondent = assertNextExternalTask(PROCESS_CASE_EVENT);
         assertCompleteExternalTask(

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ClaimantResponseSpecTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ClaimantResponseSpecTest.java
@@ -27,10 +27,8 @@ class ClaimantResponseSpecTest extends BpmnBaseTest {
     private static final String NOTIFY_RPA_ON_CONTINUOUS_FEED_ACTIVITY_ID = "NotifyRoboticsOnContinuousFeed";
     private static final String NOTIFY_RPA_ON_CASE_HANDED_OFFLINE = "NOTIFY_RPA_ON_CASE_HANDED_OFFLINE";
     private static final String NOTIFY_RPA_ON_CASE_HANDED_OFFLINE_ACTIVITY_ID = "NotifyRoboticsOnCaseHandedOffline";
-    private static final String NOTIFY_LIP_RESP_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED =
-        "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED_LIP";
     private static final String NOTIFY_LIP_RESP_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED_ACTIVITY_ID =
-        "ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1Lip";
+        "ClaimantResponseConfirmsNotToProceedLipNotify";
     public static final String PROCEED_OFFLINE_FOR_RESPONSE_TO_DEFENCE_ACTIVITY_ID
         = "ProceedOfflineForResponseToDefence";
     private static final String CLAIMANT_RESPONSE_AGREED_SETTLED_PART_ADMIT_NOTIFY_ACTIVITY_ID =
@@ -370,7 +368,7 @@ class ClaimantResponseSpecTest extends BpmnBaseTest {
         assertCompleteExternalTask(
             notifyLipRespondent,
             PROCESS_CASE_EVENT,
-            NOTIFY_LIP_RESP_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED,
+            NOTIFY_EVENT,
             NOTIFY_LIP_RESP_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED_ACTIVITY_ID
         );
         createDefendantDashboardNotification();
@@ -423,7 +421,7 @@ class ClaimantResponseSpecTest extends BpmnBaseTest {
         assertCompleteExternalTask(
             notifyLipRespondent,
             PROCESS_CASE_EVENT,
-            NOTIFY_LIP_RESP_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED,
+            NOTIFY_EVENT,
             NOTIFY_LIP_RESP_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED_ACTIVITY_ID
         );
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ClaimantResponseSpecTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ClaimantResponseSpecTest.java
@@ -39,10 +39,9 @@ class ClaimantResponseSpecTest extends BpmnBaseTest {
         "ClaimantAgreedSettledPartAdmitNotifyLip";
     private static final String CREATE_DEFENDANT_DASHBOARD_NOTIFICATION_FOR_CLAIMANT_RESPONSE = "CREATE_DEFENDANT_DASHBOARD_NOTIFICATION_FOR_CLAIMANT_RESPONSE";
     private static final String CREATE_DEFENDANT_DASHBOARD_NOTIFICATION_FOR_CLAIMANT_RESPONSE_EVENT_ID = "GenerateDashboardNotificationRespondent1";
-    private static final String NOTIFY_RESPONDENT_SOLICITOR1_CONFIRMS_NOT_TO_PROCEED = "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED";
-    private static final String NOTIFY_RESPONDENT_SOLICITOR1_CONFIRMS_NOT_TO_PROCEED_EVENT_ID = "ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1";
-    private static final String NOTIFY_RESPONDENT_SOLICITOR1_CONFIRMS_NOT_TO_PROCEED_CC = "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED_CC";
-    private static final String NOTIFY_RESPONDENT_SOLICITOR1_CLAIMANT_CONFIRMS_NOT_TO_PROCEED_CC_EVENT_ID = "ClaimantConfirmsNotToProceedNotifyApplicantSolicitor1CC";
+    private static final String NOTIFY_RESPONDENT_SOLICITOR1_CONFIRMS_NOT_TO_PROCEED_EVENT_ID = "ClaimantResponseConfirmsNotToProceedNotify";
+
+    private static final String NOTIFY_EVENT = "NOTIFY_EVENT";
 
     public ClaimantResponseSpecTest() {
         super("claimant_response_spec.bpmn", "CLAIMANT_RESPONSE_PROCESS_ID_SPEC");
@@ -220,20 +219,12 @@ class ClaimantResponseSpecTest extends BpmnBaseTest {
             variables
         );
 
-        ExternalTask notifyClimantLR = assertNextExternalTask(PROCESS_CASE_EVENT);
+        ExternalTask notifyParties = assertNextExternalTask(PROCESS_CASE_EVENT);
         assertCompleteExternalTask(
-            notifyClimantLR,
+            notifyParties,
             PROCESS_CASE_EVENT,
-            "NOTIFY_CLAIMANT_FOR_RESPONDENT1_REJECT_REPAYMENT",
-            "ClaimantDisAgreeRepaymentPlanNotifyApplicant"
-        );
-
-        ExternalTask notifyRespondent = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            notifyRespondent,
-            PROCESS_CASE_EVENT,
-            "NOTIFY_LIP_DEFENDANT_REJECT_REPAYMENT",
-            "ClaimantDisAgreedRepaymentPlanNotifyLip"
+            NOTIFY_EVENT,
+            "ClaimantResponseNotAgreedRepaymentNotify"
         );
 
         //complete the Robotics notification
@@ -312,22 +303,13 @@ class ClaimantResponseSpecTest extends BpmnBaseTest {
             variables
         );
 
-        //complete the notification to respondent
-        ExternalTask notifyRespondent = assertNextExternalTask(PROCESS_CASE_EVENT);
+        //complete the notification to all parties
+        ExternalTask notifyParties = assertNextExternalTask(PROCESS_CASE_EVENT);
         assertCompleteExternalTask(
-            notifyRespondent,
+            notifyParties,
             PROCESS_CASE_EVENT,
-            "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_TO_PROCEED",
-            "ClaimantConfirmsToProceedNotifyRespondentSolicitor1"
-        );
-
-        //complete the CC notification to applicant
-        ExternalTask notifyApplicant = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            notifyApplicant,
-            PROCESS_CASE_EVENT,
-            "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_TO_PROCEED_CC",
-            "ClaimantConfirmsToProceedNotifyApplicantSolicitor1CC"
+            NOTIFY_EVENT,
+            "ClaimantConfirmsToProceedNotify"
         );
 
         //complete the Robotics notification
@@ -475,20 +457,12 @@ class ClaimantResponseSpecTest extends BpmnBaseTest {
             variables
         );
 
-        ExternalTask notifyApplicantLR = assertNextExternalTask(PROCESS_CASE_EVENT);
+        ExternalTask notifyParties = assertNextExternalTask(PROCESS_CASE_EVENT);
         assertCompleteExternalTask(
-            notifyApplicantLR,
+            notifyParties,
             PROCESS_CASE_EVENT,
-            "NOTIFY_APPLICANT_MEDIATION_AGREEMENT",
-            "ClaimantDefendantAgreedMediationNotifyApplicant"
-        );
-
-        ExternalTask notifyRespondent = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            notifyRespondent,
-            PROCESS_CASE_EVENT,
-            "NOTIFY_RESPONDENT_MEDIATION_AGREEMENT",
-            "ClaimantDefendantAgreedMediationNotifyRespondent"
+            NOTIFY_EVENT,
+            "ClaimantDefendantAgreedMediationNotify"
         );
 
         ExternalTask generateDQ = assertNextExternalTask(PROCESS_CASE_EVENT);
@@ -538,28 +512,12 @@ class ClaimantResponseSpecTest extends BpmnBaseTest {
             variables
         );
 
-        ExternalTask notifyApplicantLR = assertNextExternalTask(PROCESS_CASE_EVENT);
+        ExternalTask notifyParties = assertNextExternalTask(PROCESS_CASE_EVENT);
         assertCompleteExternalTask(
-            notifyApplicantLR,
+            notifyParties,
             PROCESS_CASE_EVENT,
-            "NOTIFY_APPLICANT_MEDIATION_AGREEMENT",
-            "ClaimantDefendantAgreedMediationNotifyApplicant"
-        );
-
-        ExternalTask notifyRespondent = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            notifyRespondent,
-            PROCESS_CASE_EVENT,
-            "NOTIFY_RESPONDENT_MEDIATION_AGREEMENT",
-            "ClaimantDefendantAgreedMediationNotifyRespondent"
-        );
-
-        ExternalTask notifyRespondent2 = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            notifyRespondent2,
-            PROCESS_CASE_EVENT,
-            "NOTIFY_RESPONDENT2_MEDIATION_AGREEMENT",
-            "ClaimantDefendantAgreedMediationNotifyRespondent2"
+            NOTIFY_EVENT,
+            "ClaimantDefendantAgreedMediationNotify"
         );
 
         ExternalTask generateDQ = assertNextExternalTask(PROCESS_CASE_EVENT);
@@ -664,22 +622,13 @@ class ClaimantResponseSpecTest extends BpmnBaseTest {
             PROCEED_OFFLINE_FOR_RESPONSE_TO_DEFENCE_ACTIVITY_ID,
             variables
         );
-        //complete the Respondent1 notification
-        ExternalTask notifyRespondentSolicitor1 = assertNextExternalTask(PROCESS_CASE_EVENT);
+        //complete the notification to all parties
+        ExternalTask notifyParties = assertNextExternalTask(PROCESS_CASE_EVENT);
         assertCompleteExternalTask(
-            notifyRespondentSolicitor1,
+            notifyParties,
             PROCESS_CASE_EVENT,
-            NOTIFY_RESPONDENT_SOLICITOR1_CONFIRMS_NOT_TO_PROCEED,
+            NOTIFY_EVENT,
             NOTIFY_RESPONDENT_SOLICITOR1_CONFIRMS_NOT_TO_PROCEED_EVENT_ID,
-            variables
-        );
-        //complete the Applicant1 notification
-        ExternalTask notifyApplicantSolicitor1 = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            notifyApplicantSolicitor1,
-            PROCESS_CASE_EVENT,
-            NOTIFY_RESPONDENT_SOLICITOR1_CONFIRMS_NOT_TO_PROCEED_CC,
-            NOTIFY_RESPONDENT_SOLICITOR1_CLAIMANT_CONFIRMS_NOT_TO_PROCEED_CC_EVENT_ID,
             variables
         );
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ClaimantResponseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ClaimantResponseTest.java
@@ -97,22 +97,13 @@ class ClaimantResponseTest extends BpmnBaseTest {
             variables
         );
 
-        //complete the notification to respondent
+        //complete the notification to parties
         ExternalTask notifyRespondent = assertNextExternalTask(PROCESS_CASE_EVENT);
         assertCompleteExternalTask(
             notifyRespondent,
             PROCESS_CASE_EVENT,
-            "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_TO_PROCEED",
-            "ClaimantConfirmsToProceedNotifyRespondentSolicitor1"
-        );
-
-        //complete the CC notification to applicant
-        ExternalTask notifyApplicant = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            notifyApplicant,
-            PROCESS_CASE_EVENT,
-            "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_TO_PROCEED_CC",
-            "ClaimantConfirmsToProceedNotifyApplicantSolicitor1CC"
+            "NOTIFY_EVENT",
+            "ClaimantConfirmsToProceedNotify"
         );
 
         //complete the Robotics notification
@@ -192,22 +183,13 @@ class ClaimantResponseTest extends BpmnBaseTest {
             variables
         );
 
-        //complete the notification to respondent
-        ExternalTask notifyRespondent = assertNextExternalTask(PROCESS_CASE_EVENT);
+        //complete the notification to parties
+        ExternalTask notifyParties = assertNextExternalTask(PROCESS_CASE_EVENT);
         assertCompleteExternalTask(
-            notifyRespondent,
+            notifyParties,
             PROCESS_CASE_EVENT,
-            "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_TO_PROCEED",
-            "ClaimantConfirmsToProceedNotifyRespondentSolicitor1"
-        );
-
-        //complete the CC notification to applicant
-        ExternalTask notifyApplicant = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            notifyApplicant,
-            PROCESS_CASE_EVENT,
-            "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_TO_PROCEED_CC",
-            "ClaimantConfirmsToProceedNotifyApplicantSolicitor1CC"
+            "NOTIFY_EVENT",
+            "ClaimantConfirmsToProceedNotify"
         );
 
         //complete the Robotics notification
@@ -276,22 +258,13 @@ class ClaimantResponseTest extends BpmnBaseTest {
             variables
         );
 
-        //complete the notification to respondent
-        ExternalTask notifyRespondent = assertNextExternalTask(PROCESS_CASE_EVENT);
+        //complete the notification to parties
+        ExternalTask notifyParties = assertNextExternalTask(PROCESS_CASE_EVENT);
         assertCompleteExternalTask(
-            notifyRespondent,
+            notifyParties,
             PROCESS_CASE_EVENT,
-            "NOTIFY_RES_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_TO_PROCEED_MULTITRACK",
-            "ClaimantConfirmsToProceedNotifyRespondentSolicitor1Multitrack"
-        );
-
-        //complete the CC notification to applicant
-        ExternalTask notifyApplicant = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            notifyApplicant,
-            PROCESS_CASE_EVENT,
-            "NOTIFY_APP_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_TO_PROCEED_CC_MULTITRACK",
-            "ClaimantConfirmsToProceedNotifyApplicantSolicitor1CCMultitrack"
+            "NOTIFY_EVENT",
+            "ClaimantConfirmsToProceedNotify"
         );
 
         //complete the Robotics notification
@@ -349,30 +322,12 @@ class ClaimantResponseTest extends BpmnBaseTest {
         );
 
         //complete the notification to respondent
-        ExternalTask notifyRespondent = assertNextExternalTask(PROCESS_CASE_EVENT);
+        ExternalTask notifyParties = assertNextExternalTask(PROCESS_CASE_EVENT);
         assertCompleteExternalTask(
-            notifyRespondent,
+            notifyParties,
             PROCESS_CASE_EVENT,
-            "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED",
-            "ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1"
-        );
-
-        //complete the notification to respondent
-        ExternalTask notifyRespondent2 = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            notifyRespondent2,
-            PROCESS_CASE_EVENT,
-            "NOTIFY_RESPONDENT_SOLICITOR2_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED",
-            "ClaimantConfirmsNotToProceedNotifyRespondentSolicitor2"
-        );
-
-        //complete the CC notification to applicant
-        ExternalTask notifyApplicant = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            notifyApplicant,
-            PROCESS_CASE_EVENT,
-            "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED_CC",
-            "ClaimantConfirmsNotToProceedNotifyApplicantSolicitor1CC"
+            "NOTIFY_EVENT",
+            "ClaimantResponseConfirmsNotToProceedNotify"
         );
 
         //complete the Robotics notification
@@ -447,31 +402,13 @@ class ClaimantResponseTest extends BpmnBaseTest {
                 APPLICATION_OFFLINE_UPDATE_CLAIM_ACTIVITY_ID
         );
 
-        //complete the notification to respondent
-        ExternalTask notifyRespondent = assertNextExternalTask(PROCESS_CASE_EVENT);
+        //complete the notification to parties
+        ExternalTask notifyParties = assertNextExternalTask(PROCESS_CASE_EVENT);
         assertCompleteExternalTask(
-            notifyRespondent,
+            notifyParties,
             PROCESS_CASE_EVENT,
-            "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED",
-            "ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1"
-        );
-
-        //complete the notification to respondent
-        ExternalTask notifyRespondent2 = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            notifyRespondent2,
-            PROCESS_CASE_EVENT,
-            "NOTIFY_RESPONDENT_SOLICITOR2_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED",
-            "ClaimantConfirmsNotToProceedNotifyRespondentSolicitor2"
-        );
-
-        //complete the CC notification to applicant
-        ExternalTask notifyApplicant = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            notifyApplicant,
-            PROCESS_CASE_EVENT,
-            "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED_CC",
-            "ClaimantConfirmsNotToProceedNotifyApplicantSolicitor1CC"
+            "NOTIFY_EVENT",
+            "ClaimantResponseConfirmsNotToProceedNotify"
         );
 
         //complete the Robotics notification


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSCCI-1883
https://tools.hmcts.net/jira/browse/DTSCCI-2000

### Change description ###

Refactor claimant response and claimant response spec so that it notifies all parties in the same events
Dependant on: https://github.com/hmcts/civil-service/pull/6462

**Before**
<img width="1069" alt="Screenshot 2025-04-29 at 09 08 28" src="https://github.com/user-attachments/assets/a0366c0a-8422-46d6-93b7-8bafcb22fa7b" />
<img width="1167" alt="Screenshot 2025-04-29 at 09 08 37" src="https://github.com/user-attachments/assets/89d0ee41-bb01-4845-b74e-bc3934b7f944" />


**After**
<img width="1044" alt="Screenshot 2025-04-29 at 09 07 01" src="https://github.com/user-attachments/assets/2de73f28-9127-4f7b-8c13-12f890c6b3ff" />
<img width="1131" alt="Screenshot 2025-06-04 at 11 45 58" src="https://github.com/user-attachments/assets/e732e4ba-45b4-416e-b077-7d50c038a38c" />



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
