### PR TITLE
CIV-16867 - Delay notifications and visibility of Manual Determination document (includes show element)

### DIFF
--- a/src/main/resources/camunda/claimant_response_cui.bpmn
+++ b/src/main/resources/camunda/claimant_response_cui.bpmn
@@ -106,7 +106,7 @@
       <bpmn:outgoing>Flow_0beyd6n</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_0beyd6n" sourceRef="Generate_LIP_Claimant_DQ" targetRef="Gateway_0btqyj3" />
-    <bpmn:sequenceFlow id="Flow_187wcee" name="Applicant proposes new repayment plan (Respondent is LTD company or organization)" sourceRef="Gateway_RESPONSE_FLOW" targetRef="ClaimantDisAgreedRepaymentPlanNotifyLip">
+    <bpmn:sequenceFlow id="Flow_187wcee" name="Applicant proposes new repayment plan (Respondent is LTD company or organization)" sourceRef="Gateway_RESPONSE_FLOW" targetRef="Gateway_0yyi3a3">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${(flowState == "MAIN.FULL_ADMIT_REJECT_REPAYMENT" || flowState == "MAIN.PART_ADMIT_REJECT_REPAYMENT") &amp;&amp; (empty flowFlags.JO_ONLINE_LIVE_ENABLED || !flowFlags.JO_ONLINE_LIVE_ENABLED)}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="Gateway_RPA_FLOW">
@@ -164,8 +164,7 @@
           <camunda:inputParameter name="caseEvent">NOTIFY_LIP_DEFENDANT_REJECT_REPAYMENT</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_187wcee</bpmn:incoming>
-      <bpmn:incoming>Flow_0ogn4r0</bpmn:incoming>
+      <bpmn:incoming>Flow_0tnuy5r</bpmn:incoming>
       <bpmn:outgoing>Flow_192ex4z</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_192ex4z" sourceRef="ClaimantDisAgreedRepaymentPlanNotifyLip" targetRef="ClaimantDisAgreeRepaymentPlanNotifyApplicant" />
@@ -195,6 +194,7 @@
         </camunda:inputOutput>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1cmu7zm</bpmn:incoming>
+      <bpmn:incoming>Flow_1b3kpvc</bpmn:incoming>
       <bpmn:outgoing>Flow_0bb0qbd</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_0bb0qbd" sourceRef="Generate_LIP_Claimant_MD" targetRef="GenerateInterlocutoryJudgementDocument" />
@@ -470,7 +470,7 @@
     <bpmn:sequenceFlow id="Flow_1ylt8a2" name="Applicant Reject Repayment And accepts Court Calculator JO Enabled" sourceRef="Gateway_RESPONSE_FLOW" targetRef="GenerateJudgmentByAdmissionPdf">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${(flowState == "MAIN.FULL_ADMIT_REJECT_REPAYMENT" || flowState == "MAIN.PART_ADMIT_REJECT_REPAYMENT") &amp;&amp; ((!empty flowFlags.JO_ONLINE_LIVE_ENABLED &amp;&amp; flowFlags.JO_ONLINE_LIVE_ENABLED) &amp;&amp; (!empty flowFlags.LIP_JUDGMENT_ADMISSION &amp;&amp; flowFlags.LIP_JUDGMENT_ADMISSION))}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0ogn4r0" name="Applicant proposes new repayment plan (Respondent is LTD company or organization) JO Enabled " sourceRef="Gateway_RESPONSE_FLOW" targetRef="ClaimantDisAgreedRepaymentPlanNotifyLip">
+    <bpmn:sequenceFlow id="Flow_0ogn4r0" name="Applicant proposes new repayment plan (Respondent is LTD company or organization) JO Enabled " sourceRef="Gateway_RESPONSE_FLOW" targetRef="Gateway_0yyi3a3">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${(flowState == "MAIN.FULL_ADMIT_REJECT_REPAYMENT" || flowState == "MAIN.PART_ADMIT_REJECT_REPAYMENT") &amp;&amp; ((!empty flowFlags.JO_ONLINE_LIVE_ENABLED &amp;&amp; flowFlags.JO_ONLINE_LIVE_ENABLED) &amp;&amp; (!empty flowFlags.LIP_JUDGMENT_ADMISSION &amp;&amp; !flowFlags.LIP_JUDGMENT_ADMISSION))}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="Gateway_1e1bap6">
@@ -484,6 +484,18 @@
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_1rtn7sw" name="Not full defence or proceed or defendant noc disabled" sourceRef="Gateway_1e1bap6" targetRef="Generate_LIP_Claimant_DQ">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState != "MAIN.FULL_DEFENCE_NOT_PROCEED" || empty flowFlags.DEFENDANT_NOC_ONLINE || !flowFlags.DEFENDANT_NOC_ONLINE}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:exclusiveGateway id="Gateway_0yyi3a3" name="welsh party ?">
+      <bpmn:incoming>Flow_0ogn4r0</bpmn:incoming>
+      <bpmn:incoming>Flow_187wcee</bpmn:incoming>
+      <bpmn:outgoing>Flow_0tnuy5r</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1b3kpvc</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0tnuy5r" name="No" sourceRef="Gateway_0yyi3a3" targetRef="ClaimantDisAgreedRepaymentPlanNotifyLip">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${(empty flowFlags.WELSH_ENABLED || !flowFlags.WELSH_ENABLED) || ((empty flowFlags.CLAIM_ISSUE_BILINGUAL || !flowFlags.CLAIM_ISSUE_BILINGUAL) &amp;&amp; (empty flowFlags.RESPONDENT_RESPONSE_LANGUAGE_IS_BILINGUAL || !flowFlags.RESPONDENT_RESPONSE_LANGUAGE_IS_BILINGUAL) &amp;&amp; (empty flowFlags.BILINGUAL_DOCS || !flowFlags.BILINGUAL_DOCS))}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1b3kpvc" name="yes" sourceRef="Gateway_0yyi3a3" targetRef="Generate_LIP_Claimant_MD">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${(!empty flowFlags.WELSH_ENABLED &amp;&amp; flowFlags.WELSH_ENABLED) &amp;&amp; ((!empty flowFlags.CLAIM_ISSUE_BILINGUAL &amp;&amp; flowFlags.CLAIM_ISSUE_BILINGUAL) || (!empty flowFlags.RESPONDENT_RESPONSE_LANGUAGE_IS_BILINGUAL &amp;&amp; flowFlags.RESPONDENT_RESPONSE_LANGUAGE_IS_BILINGUAL) || (!empty flowFlags.BILINGUAL_DOCS &amp;&amp; flowFlags.BILINGUAL_DOCS))}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
   </bpmn:process>
   <bpmn:message id="Message_0ttrrz3" name="CLAIMANT_RESPONSE_CUI" />
@@ -549,31 +561,15 @@
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1i7id8i" bpmnElement="ClaimantDisAgreedRepaymentPlanNotifyLip">
-        <dc:Bounds x="550" y="960" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_13aq65z" bpmnElement="ClaimantDisAgreeRepaymentPlanNotifyApplicant">
-        <dc:Bounds x="680" y="960" width="100" height="80" />
+        <dc:Bounds x="770" y="960" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0azkwrd" bpmnElement="ProceedOffline">
         <dc:Bounds x="1650" y="730" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1lw8al6" bpmnElement="Generate_LIP_Claimant_MD">
-        <dc:Bounds x="840" y="960" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1yd2fq6_di" bpmnElement="updateClaimantIntentionClaimStateID">
         <dc:Bounds x="1730" y="463" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0fnev35" bpmnElement="GenerateInterlocutoryJudgementDocument">
-        <dc:Bounds x="990" y="960" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1qn5wbf" bpmnElement="GenerateJudgmentByDeterminationPdf">
-        <dc:Bounds x="1190" y="960" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1irg6vc" bpmnElement="GenerateJudgmentByAdmissionPdf">
@@ -664,6 +660,28 @@
       <bpmndi:BPMNShape id="Gateway_1e1bap6_di" bpmnElement="Gateway_1e1bap6" isMarkerVisible="true">
         <dc:Bounds x="1225" y="605" width="50" height="50" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0yyi3a3_di" bpmnElement="Gateway_0yyi3a3" isMarkerVisible="true">
+        <dc:Bounds x="675" y="975" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="678" y="953" width="64" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1qn5wbf" bpmnElement="GenerateJudgmentByDeterminationPdf">
+        <dc:Bounds x="1320" y="960" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0fnev35" bpmnElement="GenerateInterlocutoryJudgementDocument">
+        <dc:Bounds x="1190" y="960" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1lw8al6" bpmnElement="Generate_LIP_Claimant_MD">
+        <dc:Bounds x="1050" y="960" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_13aq65z" bpmnElement="ClaimantDisAgreeRepaymentPlanNotifyApplicant">
+        <dc:Bounds x="920" y="960" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0yhzfu9_di" bpmnElement="Event_0yhzfu9">
         <dc:Bounds x="272" y="445" width="36" height="36" />
       </bpmndi:BPMNShape>
@@ -723,7 +741,7 @@
       <bpmndi:BPMNEdge id="Flow_187wcee_di" bpmnElement="Flow_187wcee">
         <di:waypoint x="440" y="528" />
         <di:waypoint x="440" y="1000" />
-        <di:waypoint x="550" y="1000" />
+        <di:waypoint x="670" y="1000" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="439" y="920" width="82" height="80" />
         </bpmndi:BPMNLabel>
@@ -778,16 +796,16 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_192ex4z_di" bpmnElement="Flow_192ex4z">
-        <di:waypoint x="650" y="1000" />
-        <di:waypoint x="680" y="1000" />
+        <di:waypoint x="870" y="1000" />
+        <di:waypoint x="920" y="1000" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1cmu7zm_di" bpmnElement="Flow_1cmu7zm">
-        <di:waypoint x="780" y="1000" />
-        <di:waypoint x="840" y="1000" />
+        <di:waypoint x="1020" y="1000" />
+        <di:waypoint x="1050" y="1000" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0bb0qbd_di" bpmnElement="Flow_0bb0qbd">
-        <di:waypoint x="940" y="1000" />
-        <di:waypoint x="990" y="1000" />
+        <di:waypoint x="1150" y="1000" />
+        <di:waypoint x="1190" y="1000" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0slswz6_di" bpmnElement="Flow_0slswz6">
         <di:waypoint x="440" y="528" />
@@ -803,8 +821,8 @@
         <di:waypoint x="1880" y="503" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0a5zz1s_di" bpmnElement="Flow_0a5zz1s">
-        <di:waypoint x="1090" y="1000" />
-        <di:waypoint x="1190" y="1000" />
+        <di:waypoint x="1290" y="1000" />
+        <di:waypoint x="1320" y="1000" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0xb2qk0_di" bpmnElement="Flow_0xb2qk0">
         <di:waypoint x="710" y="770" />
@@ -984,8 +1002,8 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1msvhgp_di" bpmnElement="Flow_1msvhgp">
-        <di:waypoint x="1240" y="960" />
-        <di:waypoint x="1240" y="910" />
+        <di:waypoint x="1370" y="960" />
+        <di:waypoint x="1370" y="910" />
         <di:waypoint x="1020" y="910" />
         <di:waypoint x="1020" y="630" />
         <di:waypoint x="1085" y="630" />
@@ -1007,10 +1025,11 @@
       <bpmndi:BPMNEdge id="Flow_0ogn4r0_di" bpmnElement="Flow_0ogn4r0">
         <di:waypoint x="440" y="528" />
         <di:waypoint x="440" y="1080" />
-        <di:waypoint x="600" y="1080" />
-        <di:waypoint x="600" y="1040" />
+        <di:waypoint x="640" y="1080" />
+        <di:waypoint x="640" y="1000" />
+        <di:waypoint x="675" y="1000" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="471" y="1040" width="82" height="93" />
+          <dc:Bounds x="489" y="1040" width="82" height="93" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_19cet4s_di" bpmnElement="Flow_19cet4s">
@@ -1026,6 +1045,22 @@
         <di:waypoint x="1250" y="543" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1261" y="553" width="77" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0tnuy5r_di" bpmnElement="Flow_0tnuy5r">
+        <di:waypoint x="725" y="1000" />
+        <di:waypoint x="770" y="1000" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="740" y="982" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1b3kpvc_di" bpmnElement="Flow_1b3kpvc">
+        <di:waypoint x="700" y="1025" />
+        <di:waypoint x="700" y="1100" />
+        <di:waypoint x="1100" y="1100" />
+        <di:waypoint x="1100" y="1040" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="892" y="1080" width="17" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>

--- a/src/main/resources/camunda/upload_translated_document_claimant_rejects_repayment_plan.bpmn
+++ b/src/main/resources/camunda/upload_translated_document_claimant_rejects_repayment_plan.bpmn
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_18h9iji" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.33.1">
+  <bpmn:process id="UPLOAD_TRANSLATED_DOCUMENT_CLAIMANT_REJECTS_REPAYMENT_PLAN" name="Upload translated document claimant rejects repayment plan" isExecutable="true" camunda:historyTimeToLive="P90D">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_0g2t112</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1oxj7lg" messageRef="Message_0ttrrz3" />
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_07ek9xj">
+      <bpmn:incoming>Flow_0qmsc9o</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="Activity_1cweuly" name="End Business Process" calledElement="EndBusinessProcess">
+      <bpmn:extensionElements>
+        <camunda:in variables="all" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0tqln2z</bpmn:incoming>
+      <bpmn:outgoing>Flow_0qmsc9o</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="Activity_0gt1863" name="Start Business Process" calledElement="StartBusinessProcess">
+      <bpmn:extensionElements>
+        <camunda:in variables="all" />
+        <camunda:out variables="all" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0g2t112</bpmn:incoming>
+      <bpmn:outgoing>Flow_122poyq</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="Event_0nc34kd">
+      <bpmn:incoming>Flow_13dgz5v</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="Event_1p3emre" name="Abort" attachedToRef="Activity_0gt1863">
+      <bpmn:outgoing>Flow_13dgz5v</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0m9vye0" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_13dgz5v" sourceRef="Event_1p3emre" targetRef="Event_0nc34kd" />
+    <bpmn:sequenceFlow id="Flow_0g2t112" sourceRef="StartEvent_1" targetRef="Activity_0gt1863" />
+    <bpmn:sequenceFlow id="Flow_0qmsc9o" sourceRef="Activity_1cweuly" targetRef="Event_07ek9xj" />
+    <bpmn:serviceTask id="ClaimantDisAgreedRepaymentPlanNotifyLip" name="Notify respondent 1" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_LIP_DEFENDANT_REJECT_REPAYMENT</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_122poyq</bpmn:incoming>
+      <bpmn:outgoing>Flow_1u9vdct</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="ClaimantDisAgreeRepaymentPlanNotifyApplicant" name="Notify applicant 1 (CC)" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_CLAIMANT_FOR_RESPONDENT1_REJECT_REPAYMENT</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1u9vdct</bpmn:incoming>
+      <bpmn:outgoing>Flow_0tqln2z</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0tqln2z" sourceRef="ClaimantDisAgreeRepaymentPlanNotifyApplicant" targetRef="Activity_1cweuly" />
+    <bpmn:sequenceFlow id="Flow_1u9vdct" sourceRef="ClaimantDisAgreedRepaymentPlanNotifyLip" targetRef="ClaimantDisAgreeRepaymentPlanNotifyApplicant" />
+    <bpmn:sequenceFlow id="Flow_122poyq" sourceRef="Activity_0gt1863" targetRef="ClaimantDisAgreedRepaymentPlanNotifyLip" />
+  </bpmn:process>
+  <bpmn:message id="Message_0ttrrz3" name="UPLOAD_TRANSLATED_DOCUMENT" />
+  <bpmn:error id="Error_1alq6sw" name="StartBusinessAbort" errorCode="ABORT" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="UPLOAD_TRANSLATED_DOCUMENT_CLAIMANT_REJECTS_REPAYMENT_PLAN">
+      <bpmndi:BPMNShape id="BPMNShape_1i7id8i" bpmnElement="ClaimantDisAgreedRepaymentPlanNotifyLip">
+        <dc:Bounds x="420" y="170" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0gt1863_di" bpmnElement="Activity_0gt1863">
+        <dc:Bounds x="250" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1diii28_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="195" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="188" y="238" width="25" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0nc34kd_di" bpmnElement="Event_0nc34kd">
+        <dc:Bounds x="282" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_13aq65z" bpmnElement="ClaimantDisAgreeRepaymentPlanNotifyApplicant">
+        <dc:Bounds x="570" y="170" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_07ek9xj_di" bpmnElement="Event_07ek9xj">
+        <dc:Bounds x="872" y="192" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_14sbez9_di" bpmnElement="Activity_1cweuly">
+        <dc:Bounds x="730" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1p3emre_di" bpmnElement="Event_1p3emre">
+        <dc:Bounds x="282" y="152" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="317" y="133" width="27" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_13dgz5v_di" bpmnElement="Flow_13dgz5v">
+        <di:waypoint x="300" y="152" />
+        <di:waypoint x="300" y="115" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0g2t112_di" bpmnElement="Flow_0g2t112">
+        <di:waypoint x="218" y="213" />
+        <di:waypoint x="250" y="213" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qmsc9o_di" bpmnElement="Flow_0qmsc9o">
+        <di:waypoint x="830" y="210" />
+        <di:waypoint x="872" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0tqln2z_di" bpmnElement="Flow_0tqln2z">
+        <di:waypoint x="670" y="212" />
+        <di:waypoint x="730" y="213" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1u9vdct_di" bpmnElement="Flow_1u9vdct">
+        <di:waypoint x="520" y="210" />
+        <di:waypoint x="570" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_122poyq_di" bpmnElement="Flow_122poyq">
+        <di:waypoint x="350" y="210" />
+        <di:waypoint x="420" y="210" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/main/resources/camunda/upload_translated_document_claimant_rejects_repayment_plan.bpmn
+++ b/src/main/resources/camunda/upload_translated_document_claimant_rejects_repayment_plan.bpmn
@@ -55,7 +55,7 @@
     </bpmn:callActivity>
     <bpmn:sequenceFlow id="Flow_0s09rb1" sourceRef="END_BUSINESS_PROCESS" targetRef="Event_0262kdl" />
   </bpmn:process>
-  <bpmn:message id="Message_1pokpru" name="UPLOAD_TRANSLATED_DOCUMENT_CLAIMANTS_DOCUMENT" />
+  <bpmn:message id="Message_1pokpru" name="UPLOAD_TRANSLATED_DOCUMENT_CLAIMANT_REJECTS_REPAYMENT_PLAN" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="UPLOAD_TRANSLATED_CLAIMANTS_DOCUMENT_PROCESS_ID">
       <bpmndi:BPMNShape id="BPMNShape_1i7id8i" bpmnElement="ClaimantDisAgreedRepaymentPlanNotifyLip">

--- a/src/main/resources/camunda/upload_translated_document_claimant_rejects_repayment_plan.bpmn
+++ b/src/main/resources/camunda/upload_translated_document_claimant_rejects_repayment_plan.bpmn
@@ -1,119 +1,123 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_18h9iji" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.33.1">
-  <bpmn:process id="UPLOAD_TRANSLATED_DOCUMENT_CLAIMANT_REJECTS_REPAYMENT_PLAN" name="Upload translated document claimant rejects repayment plan" isExecutable="true" camunda:historyTimeToLive="P90D">
-    <bpmn:startEvent id="StartEvent_1" name="Start">
-      <bpmn:outgoing>Flow_0g2t112</bpmn:outgoing>
-      <bpmn:messageEventDefinition id="MessageEventDefinition_1oxj7lg" messageRef="Message_0ttrrz3" />
-    </bpmn:startEvent>
-    <bpmn:endEvent id="Event_07ek9xj">
-      <bpmn:incoming>Flow_0qmsc9o</bpmn:incoming>
-    </bpmn:endEvent>
-    <bpmn:callActivity id="Activity_1cweuly" name="End Business Process" calledElement="EndBusinessProcess">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ranzx9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.33.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.19.0">
+  <bpmn:process id="UPLOAD_TRANSLATED_CLAIMANTS_DOCUMENT_PROCESS_ID" name="Upload translated claimant rejects repayment plan" isExecutable="true" camunda:historyTimeToLive="180">
+    <bpmn:callActivity id="START_BUSINESS_PROCESS" name="Start Business Process" calledElement="StartBusinessProcess">
       <bpmn:extensionElements>
-        <camunda:in variables="all" />
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0tqln2z</bpmn:incoming>
-      <bpmn:outgoing>Flow_0qmsc9o</bpmn:outgoing>
-    </bpmn:callActivity>
-    <bpmn:callActivity id="Activity_0gt1863" name="Start Business Process" calledElement="StartBusinessProcess">
-      <bpmn:extensionElements>
-        <camunda:in variables="all" />
         <camunda:out variables="all" />
+        <camunda:in variables="all" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0g2t112</bpmn:incoming>
-      <bpmn:outgoing>Flow_122poyq</bpmn:outgoing>
+      <bpmn:incoming>Flow_0cfl6cy</bpmn:incoming>
+      <bpmn:outgoing>Flow_1b0wlsx</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:endEvent id="Event_0nc34kd">
-      <bpmn:incoming>Flow_13dgz5v</bpmn:incoming>
-    </bpmn:endEvent>
-    <bpmn:boundaryEvent id="Event_1p3emre" name="Abort" attachedToRef="Activity_0gt1863">
-      <bpmn:outgoing>Flow_13dgz5v</bpmn:outgoing>
-      <bpmn:errorEventDefinition id="ErrorEventDefinition_0m9vye0" />
+    <bpmn:startEvent id="UPLOAD_TRANSLATED_CLAIMANTS_DOCUMENT" name="Start">
+      <bpmn:outgoing>Flow_0cfl6cy</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0bf75ki" messageRef="Message_1pokpru" />
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0cfl6cy" sourceRef="UPLOAD_TRANSLATED_CLAIMANTS_DOCUMENT" targetRef="START_BUSINESS_PROCESS" />
+    <bpmn:boundaryEvent id="Event_1dduelw" name="Abort" attachedToRef="START_BUSINESS_PROCESS">
+      <bpmn:outgoing>Flow_1xm6eza</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_1fzdgsm" />
     </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_13dgz5v" sourceRef="Event_1p3emre" targetRef="Event_0nc34kd" />
-    <bpmn:sequenceFlow id="Flow_0g2t112" sourceRef="StartEvent_1" targetRef="Activity_0gt1863" />
-    <bpmn:sequenceFlow id="Flow_0qmsc9o" sourceRef="Activity_1cweuly" targetRef="Event_07ek9xj" />
+    <bpmn:endEvent id="Event_0qbq48j">
+      <bpmn:incoming>Flow_1xm6eza</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1xm6eza" sourceRef="Event_1dduelw" targetRef="Event_0qbq48j" />
+    <bpmn:sequenceFlow id="Flow_1b0wlsx" sourceRef="START_BUSINESS_PROCESS" targetRef="ClaimantDisAgreedRepaymentPlanNotifyLip" />
     <bpmn:serviceTask id="ClaimantDisAgreedRepaymentPlanNotifyLip" name="Notify respondent 1" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
           <camunda:inputParameter name="caseEvent">NOTIFY_LIP_DEFENDANT_REJECT_REPAYMENT</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_122poyq</bpmn:incoming>
-      <bpmn:outgoing>Flow_1u9vdct</bpmn:outgoing>
+      <bpmn:incoming>Flow_1b0wlsx</bpmn:incoming>
+      <bpmn:outgoing>Flow_09axe9d</bpmn:outgoing>
     </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_09axe9d" sourceRef="ClaimantDisAgreedRepaymentPlanNotifyLip" targetRef="ClaimantDisAgreeRepaymentPlanNotifyApplicant" />
     <bpmn:serviceTask id="ClaimantDisAgreeRepaymentPlanNotifyApplicant" name="Notify applicant 1 (CC)" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
           <camunda:inputParameter name="caseEvent">NOTIFY_CLAIMANT_FOR_RESPONDENT1_REJECT_REPAYMENT</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1u9vdct</bpmn:incoming>
-      <bpmn:outgoing>Flow_0tqln2z</bpmn:outgoing>
+      <bpmn:incoming>Flow_09axe9d</bpmn:incoming>
+      <bpmn:outgoing>Flow_17czt3k</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0tqln2z" sourceRef="ClaimantDisAgreeRepaymentPlanNotifyApplicant" targetRef="Activity_1cweuly" />
-    <bpmn:sequenceFlow id="Flow_1u9vdct" sourceRef="ClaimantDisAgreedRepaymentPlanNotifyLip" targetRef="ClaimantDisAgreeRepaymentPlanNotifyApplicant" />
-    <bpmn:sequenceFlow id="Flow_122poyq" sourceRef="Activity_0gt1863" targetRef="ClaimantDisAgreedRepaymentPlanNotifyLip" />
+    <bpmn:endEvent id="Event_0262kdl">
+      <bpmn:incoming>Flow_0s09rb1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_17czt3k" sourceRef="ClaimantDisAgreeRepaymentPlanNotifyApplicant" targetRef="END_BUSINESS_PROCESS" />
+    <bpmn:callActivity id="END_BUSINESS_PROCESS" name="End Business Process" calledElement="EndBusinessProcess">
+      <bpmn:extensionElements>
+        <camunda:in variables="all" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_17czt3k</bpmn:incoming>
+      <bpmn:outgoing>Flow_0s09rb1</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_0s09rb1" sourceRef="END_BUSINESS_PROCESS" targetRef="Event_0262kdl" />
   </bpmn:process>
-  <bpmn:message id="Message_0ttrrz3" name="UPLOAD_TRANSLATED_DOCUMENT" />
-  <bpmn:error id="Error_1alq6sw" name="StartBusinessAbort" errorCode="ABORT" />
+  <bpmn:message id="Message_1pokpru" name="UPLOAD_TRANSLATED_DOCUMENT_CLAIMANTS_DOCUMENT" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="UPLOAD_TRANSLATED_DOCUMENT_CLAIMANT_REJECTS_REPAYMENT_PLAN">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="UPLOAD_TRANSLATED_CLAIMANTS_DOCUMENT_PROCESS_ID">
       <bpmndi:BPMNShape id="BPMNShape_1i7id8i" bpmnElement="ClaimantDisAgreedRepaymentPlanNotifyLip">
-        <dc:Bounds x="420" y="170" width="100" height="80" />
+        <dc:Bounds x="480" y="180" width="100" height="80" />
         <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0gt1863_di" bpmnElement="Activity_0gt1863">
-        <dc:Bounds x="250" y="170" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1diii28_di" bpmnElement="StartEvent_1">
-        <dc:Bounds x="182" y="195" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="188" y="238" width="25" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0nc34kd_di" bpmnElement="Event_0nc34kd">
-        <dc:Bounds x="282" y="79" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_13aq65z" bpmnElement="ClaimantDisAgreeRepaymentPlanNotifyApplicant">
-        <dc:Bounds x="570" y="170" width="100" height="80" />
+        <dc:Bounds x="630" y="180" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_07ek9xj_di" bpmnElement="Event_07ek9xj">
-        <dc:Bounds x="872" y="192" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_10jropq_di" bpmnElement="START_BUSINESS_PROCESS">
+        <dc:Bounds x="280" y="180" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_14sbez9_di" bpmnElement="Activity_1cweuly">
-        <dc:Bounds x="730" y="170" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1p3emre_di" bpmnElement="Event_1p3emre">
-        <dc:Bounds x="282" y="152" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_0ptcm16_di" bpmnElement="UPLOAD_TRANSLATED_CLAIMANTS_DOCUMENT">
+        <dc:Bounds x="192" y="202" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="317" y="133" width="27" height="14" />
+          <dc:Bounds x="199" y="245" width="25" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_13dgz5v_di" bpmnElement="Flow_13dgz5v">
-        <di:waypoint x="300" y="152" />
-        <di:waypoint x="300" y="115" />
+      <bpmndi:BPMNShape id="Event_0qbq48j_di" bpmnElement="Event_0qbq48j">
+        <dc:Bounds x="312" y="72" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0uio47l_di" bpmnElement="END_BUSINESS_PROCESS">
+        <dc:Bounds x="790" y="180" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0262kdl_di" bpmnElement="Event_0262kdl">
+        <dc:Bounds x="952" y="202" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="737" y="245" width="8" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1dduelw_di" bpmnElement="Event_1dduelw">
+        <dc:Bounds x="312" y="162" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="337" y="143" width="27" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0cfl6cy_di" bpmnElement="Flow_0cfl6cy">
+        <di:waypoint x="228" y="220" />
+        <di:waypoint x="280" y="220" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0g2t112_di" bpmnElement="Flow_0g2t112">
-        <di:waypoint x="218" y="213" />
-        <di:waypoint x="250" y="213" />
+      <bpmndi:BPMNEdge id="Flow_1xm6eza_di" bpmnElement="Flow_1xm6eza">
+        <di:waypoint x="330" y="162" />
+        <di:waypoint x="330" y="108" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0qmsc9o_di" bpmnElement="Flow_0qmsc9o">
-        <di:waypoint x="830" y="210" />
-        <di:waypoint x="872" y="210" />
+      <bpmndi:BPMNEdge id="Flow_0s09rb1_di" bpmnElement="Flow_0s09rb1">
+        <di:waypoint x="890" y="220" />
+        <di:waypoint x="952" y="220" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0tqln2z_di" bpmnElement="Flow_0tqln2z">
-        <di:waypoint x="670" y="212" />
-        <di:waypoint x="730" y="213" />
+      <bpmndi:BPMNEdge id="Flow_1b0wlsx_di" bpmnElement="Flow_1b0wlsx">
+        <di:waypoint x="380" y="220" />
+        <di:waypoint x="480" y="220" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1u9vdct_di" bpmnElement="Flow_1u9vdct">
-        <di:waypoint x="520" y="210" />
-        <di:waypoint x="570" y="210" />
+      <bpmndi:BPMNEdge id="Flow_09axe9d_di" bpmnElement="Flow_09axe9d">
+        <di:waypoint x="580" y="220" />
+        <di:waypoint x="630" y="220" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_122poyq_di" bpmnElement="Flow_122poyq">
-        <di:waypoint x="350" y="210" />
-        <di:waypoint x="420" y="210" />
+      <bpmndi:BPMNEdge id="Flow_17czt3k_di" bpmnElement="Flow_17czt3k">
+        <di:waypoint x="730" y="220" />
+        <di:waypoint x="790" y="220" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ClaimantResponseCuiTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ClaimantResponseCuiTest.java
@@ -326,7 +326,7 @@ public class ClaimantResponseCuiTest extends BpmnBaseTest {
 
     @ParameterizedTest
     @CsvSource({"true,false", "true, true"})
-    void shouldRunProcess_ClaimIsInFullAdmitRejectRepaymentAndWelshFTisOff(boolean isClaimantBilingual, boolean isRespondentBilingual ) {
+    void shouldRunProcess_ClaimIsInFullAdmitRejectRepaymentAndWelshFTisOff(boolean isClaimantBilingual, boolean isRespondentBilingual) {
 
         //assert process has started
         assertFalse(processInstance.isEnded());
@@ -361,8 +361,6 @@ public class ClaimantResponseCuiTest extends BpmnBaseTest {
         endBusinessProcess();
         assertNoExternalTasksLeft();
     }
-
-
 
     @ParameterizedTest
     @ValueSource(strings = {"true", "false"})

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ClaimantResponseCuiTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ClaimantResponseCuiTest.java
@@ -5,6 +5,7 @@ import org.camunda.bpm.engine.variable.VariableMap;
 import org.camunda.bpm.engine.variable.Variables;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Map;
@@ -287,6 +288,81 @@ public class ClaimantResponseCuiTest extends BpmnBaseTest {
         endBusinessProcess();
         assertNoExternalTasksLeft();
     }
+
+    @ParameterizedTest
+    @CsvSource({"true,false", "false,true"})
+    void shouldRunProcess_ClaimIsInFullAdmitRejectRepaymentAndWelshParty(boolean isRespondentBilingual, boolean isClaimantBilingual) {
+
+        //assert process has started
+        assertFalse(processInstance.isEnded());
+
+        //assert message start event
+        assertThat(getProcessDefinitionByMessage(MESSAGE_NAME).getKey()).isEqualTo(PROCESS_ID);
+        ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
+        VariableMap variables = Variables.createVariables();
+        variables.putValue("flowState", "MAIN.FULL_ADMIT_REJECT_REPAYMENT");
+        variables.put(FLOW_FLAGS, Map.of(
+            LIP_JUDGMENT_ADMISSION, false,
+            CLAIM_ISSUE_BILINGUAL, isClaimantBilingual,
+            RESPONDENT_RESPONSE_LANGUAGE_IS_BILINGUAL, isRespondentBilingual,
+            BILINGUAL_DOCS, false,
+            WELSH_ENABLED, true,
+            JO_ONLINE_LIVE_ENABLED, false));
+        assertCompleteExternalTask(
+            startBusiness,
+            START_BUSINESS_TOPIC,
+            START_BUSINESS_EVENT,
+            START_BUSINESS_ACTIVITY,
+            variables
+        );
+
+        generateManualDeterminationPdf();
+        requestInterlockJudgement();
+        generateJudgmentByDeterminationPdf();
+        generateDQPdf();
+        endBusinessProcess();
+        assertNoExternalTasksLeft();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"true,false", "true, true"})
+    void shouldRunProcess_ClaimIsInFullAdmitRejectRepaymentAndWelshFTisOff(boolean isClaimantBilingual, boolean isRespondentBilingual ) {
+
+        //assert process has started
+        assertFalse(processInstance.isEnded());
+
+        //assert message start event
+        assertThat(getProcessDefinitionByMessage(MESSAGE_NAME).getKey()).isEqualTo(PROCESS_ID);
+        ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
+        VariableMap variables = Variables.createVariables();
+        variables.putValue("flowState", "MAIN.FULL_ADMIT_REJECT_REPAYMENT");
+        variables.put(FLOW_FLAGS, Map.of(
+            LIP_JUDGMENT_ADMISSION, false,
+            CLAIM_ISSUE_BILINGUAL, isClaimantBilingual,
+            RESPONDENT_RESPONSE_LANGUAGE_IS_BILINGUAL, isRespondentBilingual,
+            BILINGUAL_DOCS, false,
+            WELSH_ENABLED, false,
+            JO_ONLINE_LIVE_ENABLED, false));
+
+        assertCompleteExternalTask(
+            startBusiness,
+            START_BUSINESS_TOPIC,
+            START_BUSINESS_EVENT,
+            START_BUSINESS_ACTIVITY,
+            variables
+        );
+
+        notifyRespondentClaimantRejectRepayment();
+        notifyClaimantClaimantRejectRepayment();
+        generateManualDeterminationPdf();
+        requestInterlockJudgement();
+        generateJudgmentByDeterminationPdf();
+        generateDQPdf();
+        endBusinessProcess();
+        assertNoExternalTasksLeft();
+    }
+
+
 
     @ParameterizedTest
     @ValueSource(strings = {"true", "false"})

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/UploadTranslatedClaimantsRejectsRepaymentPlanDocumentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/UploadTranslatedClaimantsRejectsRepaymentPlanDocumentTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class UploadTranslatedClaimantsRejectsRepaymentPlanDocumentTest extends BpmnBaseTest {
 
-    private static final String MESSAGE_NAME = "UPLOAD_TRANSLATED_DOCUMENT_CLAIMANTS_DOCUMENT";
+    private static final String MESSAGE_NAME = "UPLOAD_TRANSLATED_DOCUMENT_CLAIMANT_REJECTS_REPAYMENT_PLAN";
     private static final String PROCESS_ID = "UPLOAD_TRANSLATED_CLAIMANTS_DOCUMENT_PROCESS_ID";
     private static final String NOTIFY_LIP_DEFENDANT_REJECT_REPAYMENT
         = "NOTIFY_LIP_DEFENDANT_REJECT_REPAYMENT";

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/UploadTranslatedClaimantsRejectsRepaymentPlanDocumentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/UploadTranslatedClaimantsRejectsRepaymentPlanDocumentTest.java
@@ -1,0 +1,73 @@
+package uk.gov.hmcts.reform.civil.bpmn;
+
+import org.camunda.bpm.engine.externaltask.ExternalTask;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class UploadTranslatedClaimantsRejectsRepaymentPlanDocumentTest extends BpmnBaseTest {
+
+    private static final String MESSAGE_NAME = "UPLOAD_TRANSLATED_DOCUMENT_CLAIMANTS_DOCUMENT";
+    private static final String PROCESS_ID = "UPLOAD_TRANSLATED_CLAIMANTS_DOCUMENT_PROCESS_ID";
+    private static final String NOTIFY_LIP_DEFENDANT_REJECT_REPAYMENT
+        = "NOTIFY_LIP_DEFENDANT_REJECT_REPAYMENT";
+
+    private static final String NOTIFY_CLAIMANT_FOR_RESPONDENT1_REJECT_REPAYMENT
+        = "NOTIFY_CLAIMANT_FOR_RESPONDENT1_REJECT_REPAYMENT";
+    private static final String NOTIFY_LIP_DEFENDANT_REJECT_REPAYMENT_ACTIVITY_ID
+        = "ClaimantDisAgreedRepaymentPlanNotifyLip";
+
+    private static final String NOTIFY_CLAIMANT_FOR_RESPONDENT1_REJECT_REPAYMENT_ACTIVITY_ID
+        = "ClaimantDisAgreeRepaymentPlanNotifyApplicant";
+
+    public UploadTranslatedClaimantsRejectsRepaymentPlanDocumentTest() {
+        super(
+            "upload_translated_document_claimant_rejects_repayment_plan.bpmn",
+            PROCESS_ID
+        );
+    }
+
+    private void notifyClaimantClaimantRejectRepayment() {
+        assertCompletedCaseEvent(NOTIFY_CLAIMANT_FOR_RESPONDENT1_REJECT_REPAYMENT, NOTIFY_CLAIMANT_FOR_RESPONDENT1_REJECT_REPAYMENT_ACTIVITY_ID);
+    }
+
+    private void notifyRespondentClaimantRejectRepayment() {
+        assertCompletedCaseEvent(NOTIFY_LIP_DEFENDANT_REJECT_REPAYMENT, NOTIFY_LIP_DEFENDANT_REJECT_REPAYMENT_ACTIVITY_ID);
+    }
+
+    private void assertCompletedCaseEvent(String eventName, String activityId) {
+        ExternalTask notificationTask = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            notificationTask,
+            PROCESS_CASE_EVENT,
+            eventName,
+            activityId
+        );
+    }
+
+    @Test
+    void shouldRunProcess_ClaimIsInFullAdmitRejectRepaymentUploadDocuments() {
+
+        //assert process has started
+        assertFalse(processInstance.isEnded());
+
+        //assert message start event
+        assertThat(getProcessDefinitionByMessage(MESSAGE_NAME).getKey()).isEqualTo(PROCESS_ID);
+        ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
+        assertCompleteExternalTask(
+            startBusiness,
+            START_BUSINESS_TOPIC,
+            START_BUSINESS_EVENT,
+            START_BUSINESS_ACTIVITY
+        );
+
+        notifyRespondentClaimantRejectRepayment();
+        notifyClaimantClaimantRejectRepayment();
+        //end business process
+        ExternalTask endBusinessProcess = assertNextExternalTask(END_BUSINESS_PROCESS);
+        completeBusinessProcess(endBusinessProcess);
+
+        assertNoExternalTasksLeft();
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-16867




### Change description ###
When a claimant rejects the repayment plan and the mail claim involves a Welsh party, the modified claimant intention flow will pause the notification.

Added new camunda to resume the paused task after WLU uploads the translated document.

![image](https://github.com/user-attachments/assets/924da8c7-0c24-4df7-857b-5e8aeed89276)

![image](https://github.com/user-attachments/assets/058e45d3-c4bf-4515-b152-8445505ec63a)



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
