### PR TITLE
CIV-16916 - Re-trigger application flow after translation uploaded (Application summary documents) - enable state change

### DIFF
--- a/src/main/resources/camunda/upload_translated_document_ga_summary_doc.bpmn
+++ b/src/main/resources/camunda/upload_translated_document_ga_summary_doc.bpmn
@@ -43,7 +43,7 @@
       <bpmn:incoming>Flow_00j9g6p</bpmn:incoming>
       <bpmn:outgoing>Flow_1o113vl</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_06pv761" name="LiP Applicant" sourceRef="Gateway_0nb8bqq" targetRef="Activity_0hyf44k">
+    <bpmn:sequenceFlow id="Flow_06pv761" name="LiP Applicant" sourceRef="Gateway_0nb8bqq" targetRef="UpdateDashboardNotifications">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.LIP_APPLICANT &amp;&amp; flowFlags.LIP_APPLICANT}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:serviceTask id="BulkPrintOrderRespondent" name="Bulk print order respondent" camunda:type="external" camunda:topic="processExternalCaseEventGASpec">
@@ -65,7 +65,7 @@
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${empty flowFlags.LIP_RESPONDENT || !flowFlags.LIP_RESPONDENT}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_1o113vl" sourceRef="BulkPrintOrderApplicant" targetRef="Gateway_14xtsk2" />
-    <bpmn:sequenceFlow id="Flow_0zobuvp" name="LiP Respondent" sourceRef="Gateway_14xtsk2" targetRef="Activity_0b9qemx">
+    <bpmn:sequenceFlow id="Flow_0zobuvp" name="LiP Respondent" sourceRef="Gateway_14xtsk2" targetRef="respondentDashboardNotification">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.LIP_RESPONDENT &amp;&amp; flowFlags.LIP_RESPONDENT}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:serviceTask id="AddDraftDocToMainCaseID" name="Add Draft Document to Parent Case" camunda:type="external" camunda:topic="updateFromGACaseEvent">
@@ -77,8 +77,8 @@
       <bpmn:incoming>Flow_07n1ssi</bpmn:incoming>
       <bpmn:outgoing>Flow_152d168</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_152d168" sourceRef="AddDraftDocToMainCaseID" targetRef="Activity_0aqp9se" />
-    <bpmn:serviceTask id="Activity_0aqp9se" name="Notifying respondents" camunda:type="external" camunda:topic="processExternalCaseEventGASpec">
+    <bpmn:sequenceFlow id="Flow_152d168" sourceRef="AddDraftDocToMainCaseID" targetRef="GeneralApplicationNotifying" />
+    <bpmn:serviceTask id="GeneralApplicationNotifying" name="Notifying respondents" camunda:type="external" camunda:topic="processExternalCaseEventGASpec">
       <bpmn:extensionElements>
         <camunda:inputOutput>
           <camunda:inputParameter name="caseEvent">NOTIFY_GENERAL_APPLICATION_RESPONDENT</camunda:inputParameter>
@@ -87,8 +87,8 @@
       <bpmn:incoming>Flow_152d168</bpmn:incoming>
       <bpmn:outgoing>Flow_1uafcbh</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1uafcbh" sourceRef="Activity_0aqp9se" targetRef="Gateway_0nb8bqq" />
-    <bpmn:serviceTask id="Activity_0hyf44k" name="Update Dashboard Notifications" camunda:type="external" camunda:topic="applicationProcessCaseEventGASpec">
+    <bpmn:sequenceFlow id="Flow_1uafcbh" sourceRef="GeneralApplicationNotifying" targetRef="Gateway_0nb8bqq" />
+    <bpmn:serviceTask id="UpdateDashboardNotifications" name="Update Dashboard Notifications" camunda:type="external" camunda:topic="applicationProcessCaseEventGASpec">
       <bpmn:extensionElements>
         <camunda:inputOutput>
           <camunda:inputParameter name="caseEvent">UPDATE_GA_DASHBOARD_NOTIFICATION</camunda:inputParameter>
@@ -97,8 +97,8 @@
       <bpmn:incoming>Flow_06pv761</bpmn:incoming>
       <bpmn:outgoing>Flow_00j9g6p</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_00j9g6p" sourceRef="Activity_0hyf44k" targetRef="BulkPrintOrderApplicant" />
-    <bpmn:serviceTask id="Activity_0b9qemx" name="Create Dashboard Notification for Respondent" camunda:type="external" camunda:topic="applicationProcessCaseEventGASpec">
+    <bpmn:sequenceFlow id="Flow_00j9g6p" sourceRef="UpdateDashboardNotifications" targetRef="BulkPrintOrderApplicant" />
+    <bpmn:serviceTask id="respondentDashboardNotification" name="Create Dashboard Notification for Respondent" camunda:type="external" camunda:topic="applicationProcessCaseEventGASpec">
       <bpmn:extensionElements>
         <camunda:inputOutput>
           <camunda:inputParameter name="caseEvent">CREATE_APPLICATION_SUBMITTED_DASHBOARD_NOTIFICATION_FOR_RESPONDENT</camunda:inputParameter>
@@ -107,7 +107,7 @@
       <bpmn:incoming>Flow_0zobuvp</bpmn:incoming>
       <bpmn:outgoing>Flow_02zbmca</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_02zbmca" sourceRef="Activity_0b9qemx" targetRef="BulkPrintOrderRespondent" />
+    <bpmn:sequenceFlow id="Flow_02zbmca" sourceRef="respondentDashboardNotification" targetRef="BulkPrintOrderRespondent" />
     <bpmn:callActivity id="Activity_0eo8p2p" name="End Business Process" calledElement="GA_EndBusinessProcess">
       <bpmn:extensionElements>
         <camunda:in variables="all" />
@@ -159,14 +159,14 @@
         <dc:Bounds x="390" y="173" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1rnrlhi" bpmnElement="Activity_0aqp9se">
+      <bpmndi:BPMNShape id="BPMNShape_1rnrlhi" bpmnElement="GeneralApplicationNotifying">
         <dc:Bounds x="530" y="173" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0qt8tph" bpmnElement="Activity_0hyf44k">
+      <bpmndi:BPMNShape id="BPMNShape_0qt8tph" bpmnElement="UpdateDashboardNotifications">
         <dc:Bounds x="760" y="300" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1erkovz" bpmnElement="Activity_0b9qemx">
+      <bpmndi:BPMNShape id="BPMNShape_1erkovz" bpmnElement="respondentDashboardNotification">
         <dc:Bounds x="1110" y="300" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>

--- a/src/main/resources/camunda/upload_translated_document_ga_summary_doc.bpmn
+++ b/src/main/resources/camunda/upload_translated_document_ga_summary_doc.bpmn
@@ -1,0 +1,256 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_18h9iji" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.33.1">
+  <bpmn:process id="UPLOAD_TRANSLATED_DOCUMENT_GA_SUMMARY_DOC" name="Upload translated document GA summary Doc" isExecutable="true" camunda:historyTimeToLive="P90D">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_0g2t112</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1oxj7lg" messageRef="Message_0ttrrz3" />
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_07ek9xj">
+      <bpmn:incoming>Flow_12hy528</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="Activity_0gt1863" name="Start Ga Business Process" calledElement="GA_StartGeneralApplicationBusinessProcess">
+      <bpmn:extensionElements>
+        <camunda:in variables="all" />
+        <camunda:out variables="all" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0g2t112</bpmn:incoming>
+      <bpmn:outgoing>Flow_07n1ssi</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="Event_0nc34kd">
+      <bpmn:incoming>Flow_13dgz5v</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="Event_1p3emre" name="Abort" attachedToRef="Activity_0gt1863">
+      <bpmn:outgoing>Flow_13dgz5v</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0m9vye0" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_13dgz5v" sourceRef="Event_1p3emre" targetRef="Event_0nc34kd" />
+    <bpmn:sequenceFlow id="Flow_0g2t112" sourceRef="StartEvent_1" targetRef="Activity_0gt1863" />
+    <bpmn:sequenceFlow id="Flow_07n1ssi" sourceRef="Activity_0gt1863" targetRef="AddDraftDocToMainCaseID" />
+    <bpmn:exclusiveGateway id="Gateway_0nb8bqq">
+      <bpmn:incoming>Flow_1uafcbh</bpmn:incoming>
+      <bpmn:outgoing>Flow_1u52am6</bpmn:outgoing>
+      <bpmn:outgoing>Flow_06pv761</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1u52am6" name="LR applicant" sourceRef="Gateway_0nb8bqq" targetRef="Gateway_14xtsk2">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${empty flowFlags.LIP_APPLICANT || !flowFlags.LIP_APPLICANT}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:serviceTask id="BulkPrintOrderApplicant" name="Bulk print order applicant" camunda:type="external" camunda:topic="processExternalCaseEventGASpec">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">SEND_TRANSLATED_ORDER_TO_LIP_APPLICANT</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_00j9g6p</bpmn:incoming>
+      <bpmn:outgoing>Flow_1o113vl</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_06pv761" name="LiP Applicant" sourceRef="Gateway_0nb8bqq" targetRef="Activity_0hyf44k">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.LIP_APPLICANT &amp;&amp; flowFlags.LIP_APPLICANT}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:serviceTask id="BulkPrintOrderRespondent" name="Bulk print order respondent" camunda:type="external" camunda:topic="processExternalCaseEventGASpec">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">SEND_TRANSLATED_ORDER_TO_LIP_RESPONDENT</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_02zbmca</bpmn:incoming>
+      <bpmn:outgoing>Flow_0xqrj4z</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:exclusiveGateway id="Gateway_14xtsk2">
+      <bpmn:incoming>Flow_1u52am6</bpmn:incoming>
+      <bpmn:incoming>Flow_1o113vl</bpmn:incoming>
+      <bpmn:outgoing>Flow_05b0ay8</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0zobuvp</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_05b0ay8" name="LR Respondent" sourceRef="Gateway_14xtsk2" targetRef="Activity_0eo8p2p">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${empty flowFlags.LIP_RESPONDENT || !flowFlags.LIP_RESPONDENT}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1o113vl" sourceRef="BulkPrintOrderApplicant" targetRef="Gateway_14xtsk2" />
+    <bpmn:sequenceFlow id="Flow_0zobuvp" name="LiP Respondent" sourceRef="Gateway_14xtsk2" targetRef="Activity_0b9qemx">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.LIP_RESPONDENT &amp;&amp; flowFlags.LIP_RESPONDENT}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:serviceTask id="AddDraftDocToMainCaseID" name="Add Draft Document to Parent Case" camunda:type="external" camunda:topic="updateFromGACaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">ADD_PDF_TO_MAIN_CASE</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_07n1ssi</bpmn:incoming>
+      <bpmn:outgoing>Flow_152d168</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_152d168" sourceRef="AddDraftDocToMainCaseID" targetRef="Activity_0aqp9se" />
+    <bpmn:serviceTask id="Activity_0aqp9se" name="Notifying respondents" camunda:type="external" camunda:topic="processExternalCaseEventGASpec">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_GENERAL_APPLICATION_RESPONDENT</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_152d168</bpmn:incoming>
+      <bpmn:outgoing>Flow_1uafcbh</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1uafcbh" sourceRef="Activity_0aqp9se" targetRef="Gateway_0nb8bqq" />
+    <bpmn:serviceTask id="Activity_0hyf44k" name="Update Dashboard Notifications" camunda:type="external" camunda:topic="applicationProcessCaseEventGASpec">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">UPDATE_GA_DASHBOARD_NOTIFICATION</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_06pv761</bpmn:incoming>
+      <bpmn:outgoing>Flow_00j9g6p</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_00j9g6p" sourceRef="Activity_0hyf44k" targetRef="BulkPrintOrderApplicant" />
+    <bpmn:serviceTask id="Activity_0b9qemx" name="Create Dashboard Notification for Respondent" camunda:type="external" camunda:topic="applicationProcessCaseEventGASpec">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">CREATE_APPLICATION_SUBMITTED_DASHBOARD_NOTIFICATION_FOR_RESPONDENT</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0zobuvp</bpmn:incoming>
+      <bpmn:outgoing>Flow_02zbmca</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_02zbmca" sourceRef="Activity_0b9qemx" targetRef="BulkPrintOrderRespondent" />
+    <bpmn:callActivity id="Activity_0eo8p2p" name="End Business Process" calledElement="GA_EndBusinessProcess">
+      <bpmn:extensionElements>
+        <camunda:in variables="all" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_05b0ay8</bpmn:incoming>
+      <bpmn:incoming>Flow_0xqrj4z</bpmn:incoming>
+      <bpmn:outgoing>Flow_12hy528</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_0xqrj4z" sourceRef="BulkPrintOrderRespondent" targetRef="Activity_0eo8p2p" />
+    <bpmn:sequenceFlow id="Flow_12hy528" sourceRef="Activity_0eo8p2p" targetRef="Event_07ek9xj" />
+  </bpmn:process>
+  <bpmn:message id="Message_0ttrrz3" name="UPLOAD_TRANSLATED_DOCUMENT_GA_SUMMARY_DOC" />
+  <bpmn:error id="Error_1alq6sw" name="StartBusinessAbort" errorCode="ABORT" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="UPLOAD_TRANSLATED_DOCUMENT_GA_SUMMARY_DOC">
+      <bpmndi:BPMNShape id="Event_1diii28_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="195" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="158" y="238" width="25" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_07ek9xj_di" bpmnElement="Event_07ek9xj">
+        <dc:Bounds x="1522" y="195" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0gt1863_di" bpmnElement="Activity_0gt1863">
+        <dc:Bounds x="230" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0nc34kd_di" bpmnElement="Event_0nc34kd">
+        <dc:Bounds x="262" y="92" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0nb8bqq_di" bpmnElement="Gateway_0nb8bqq" isMarkerVisible="true">
+        <dc:Bounds x="675" y="188" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1167" y="155" width="27" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1gjfcvf_di" bpmnElement="BulkPrintOrderApplicant">
+        <dc:Bounds x="910" y="300" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0pwnstm_di" bpmnElement="BulkPrintOrderRespondent">
+        <dc:Bounds x="1240" y="300" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_14xtsk2_di" bpmnElement="Gateway_14xtsk2" isMarkerVisible="true">
+        <dc:Bounds x="1015" y="188" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1cajp65" bpmnElement="AddDraftDocToMainCaseID">
+        <dc:Bounds x="390" y="173" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1rnrlhi" bpmnElement="Activity_0aqp9se">
+        <dc:Bounds x="530" y="173" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0qt8tph" bpmnElement="Activity_0hyf44k">
+        <dc:Bounds x="760" y="300" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1erkovz" bpmnElement="Activity_0b9qemx">
+        <dc:Bounds x="1110" y="300" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0eo8p2p_di" bpmnElement="Activity_0eo8p2p">
+        <dc:Bounds x="1370" y="173" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1p3emre_di" bpmnElement="Event_1p3emre">
+        <dc:Bounds x="262" y="152" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="297" y="133" width="27" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_13dgz5v_di" bpmnElement="Flow_13dgz5v">
+        <di:waypoint x="280" y="152" />
+        <di:waypoint x="280" y="128" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0g2t112_di" bpmnElement="Flow_0g2t112">
+        <di:waypoint x="188" y="213" />
+        <di:waypoint x="230" y="213" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07n1ssi_di" bpmnElement="Flow_07n1ssi">
+        <di:waypoint x="330" y="210" />
+        <di:waypoint x="390" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1u52am6_di" bpmnElement="Flow_1u52am6">
+        <di:waypoint x="725" y="213" />
+        <di:waypoint x="1015" y="213" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="839" y="195" width="63" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06pv761_di" bpmnElement="Flow_06pv761">
+        <di:waypoint x="700" y="238" />
+        <di:waypoint x="700" y="340" />
+        <di:waypoint x="760" y="340" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="708" y="265" width="65" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_05b0ay8_di" bpmnElement="Flow_05b0ay8">
+        <di:waypoint x="1065" y="213" />
+        <di:waypoint x="1370" y="213" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1205" y="195" width="78" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1o113vl_di" bpmnElement="Flow_1o113vl">
+        <di:waypoint x="1010" y="340" />
+        <di:waypoint x="1040" y="340" />
+        <di:waypoint x="1040" y="238" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0zobuvp_di" bpmnElement="Flow_0zobuvp">
+        <di:waypoint x="1040" y="238" />
+        <di:waypoint x="1040" y="340" />
+        <di:waypoint x="1110" y="340" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1052" y="275" width="80" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_152d168_di" bpmnElement="Flow_152d168">
+        <di:waypoint x="490" y="213" />
+        <di:waypoint x="530" y="213" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1uafcbh_di" bpmnElement="Flow_1uafcbh">
+        <di:waypoint x="630" y="213" />
+        <di:waypoint x="675" y="213" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00j9g6p_di" bpmnElement="Flow_00j9g6p">
+        <di:waypoint x="860" y="340" />
+        <di:waypoint x="910" y="340" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_02zbmca_di" bpmnElement="Flow_02zbmca">
+        <di:waypoint x="1210" y="340" />
+        <di:waypoint x="1240" y="340" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0xqrj4z_di" bpmnElement="Flow_0xqrj4z">
+        <di:waypoint x="1340" y="340" />
+        <di:waypoint x="1420" y="340" />
+        <di:waypoint x="1420" y="253" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_12hy528_di" bpmnElement="Flow_12hy528">
+        <di:waypoint x="1470" y="213" />
+        <di:waypoint x="1522" y="213" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/main/resources/camunda/upload_translated_document_ga_summary_response_doc.bpmn
+++ b/src/main/resources/camunda/upload_translated_document_ga_summary_response_doc.bpmn
@@ -1,0 +1,273 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_18h9iji" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.33.1">
+  <bpmn:process id="UPLOAD_TRANSLATED_DOCUMENT_GA_SUMMARY_RESPONSE_DOC" name="Upload translated document GA summary response doc" isExecutable="true" camunda:historyTimeToLive="P90D">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_0g2t112</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1oxj7lg" messageRef="Message_0ttrrz3" />
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_07ek9xj">
+      <bpmn:incoming>Flow_12hy528</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="Activity_0gt1863" name="Start Ga Business Process" calledElement="GA_StartGeneralApplicationBusinessProcess">
+      <bpmn:extensionElements>
+        <camunda:in variables="all" />
+        <camunda:out variables="all" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0g2t112</bpmn:incoming>
+      <bpmn:outgoing>Flow_07n1ssi</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="Event_0nc34kd">
+      <bpmn:incoming>Flow_13dgz5v</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="Event_1p3emre" name="Abort" attachedToRef="Activity_0gt1863">
+      <bpmn:outgoing>Flow_13dgz5v</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0m9vye0" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_13dgz5v" sourceRef="Event_1p3emre" targetRef="Event_0nc34kd" />
+    <bpmn:sequenceFlow id="Flow_0g2t112" sourceRef="StartEvent_1" targetRef="Activity_0gt1863" />
+    <bpmn:sequenceFlow id="Flow_07n1ssi" sourceRef="Activity_0gt1863" targetRef="AddDraftDocToMainCaseID" />
+    <bpmn:exclusiveGateway id="Gateway_0nb8bqq">
+      <bpmn:incoming>Flow_01ow93i</bpmn:incoming>
+      <bpmn:incoming>Flow_15j5tee</bpmn:incoming>
+      <bpmn:outgoing>Flow_1u52am6</bpmn:outgoing>
+      <bpmn:outgoing>Flow_06pv761</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1u52am6" name="LR applicant" sourceRef="Gateway_0nb8bqq" targetRef="Gateway_14xtsk2">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${empty flowFlags.LIP_APPLICANT || !flowFlags.LIP_APPLICANT}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:serviceTask id="BulkPrintOrderApplicant" name="Bulk print order applicant" camunda:type="external" camunda:topic="processExternalCaseEventGASpec">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">SEND_TRANSLATED_ORDER_TO_LIP_APPLICANT</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_06pv761</bpmn:incoming>
+      <bpmn:outgoing>Flow_1o113vl</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_06pv761" name="LiP Applicant" sourceRef="Gateway_0nb8bqq" targetRef="BulkPrintOrderApplicant">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.LIP_APPLICANT &amp;&amp; flowFlags.LIP_APPLICANT}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:serviceTask id="BulkPrintOrderRespondent" name="Bulk print order respondent" camunda:type="external" camunda:topic="processExternalCaseEventGASpec">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">SEND_TRANSLATED_ORDER_TO_LIP_RESPONDENT</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0zobuvp</bpmn:incoming>
+      <bpmn:outgoing>Flow_0xqrj4z</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:exclusiveGateway id="Gateway_14xtsk2">
+      <bpmn:incoming>Flow_1u52am6</bpmn:incoming>
+      <bpmn:incoming>Flow_1o113vl</bpmn:incoming>
+      <bpmn:outgoing>Flow_05b0ay8</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0zobuvp</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_05b0ay8" name="LR Respondent" sourceRef="Gateway_14xtsk2" targetRef="Activity_0eo8p2p">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${empty flowFlags.LIP_RESPONDENT || !flowFlags.LIP_RESPONDENT}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1o113vl" sourceRef="BulkPrintOrderApplicant" targetRef="Gateway_14xtsk2" />
+    <bpmn:sequenceFlow id="Flow_0zobuvp" name="LiP Respondent" sourceRef="Gateway_14xtsk2" targetRef="BulkPrintOrderRespondent">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.LIP_RESPONDENT &amp;&amp; flowFlags.LIP_RESPONDENT}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:serviceTask id="AddDraftDocToMainCaseID" name="Add Draft Document to Parent Case" camunda:type="external" camunda:topic="updateFromGACaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">ADD_PDF_TO_MAIN_CASE</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_07n1ssi</bpmn:incoming>
+      <bpmn:outgoing>Flow_152d168</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_152d168" sourceRef="AddDraftDocToMainCaseID" targetRef="WaitCivilDraftDocumentUpdatedId" />
+    <bpmn:callActivity id="Activity_0eo8p2p" name="End Business Process" calledElement="GA_EndBusinessProcess">
+      <bpmn:extensionElements>
+        <camunda:in variables="all" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_05b0ay8</bpmn:incoming>
+      <bpmn:incoming>Flow_0xqrj4z</bpmn:incoming>
+      <bpmn:outgoing>Flow_12hy528</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_0xqrj4z" sourceRef="BulkPrintOrderRespondent" targetRef="Activity_0eo8p2p" />
+    <bpmn:sequenceFlow id="Flow_12hy528" sourceRef="Activity_0eo8p2p" targetRef="Event_07ek9xj" />
+    <bpmn:serviceTask id="WaitCivilDraftDocumentUpdatedId" name="Wait Civil Draft Document Updated" camunda:type="external" camunda:topic="WAIT_CIVIL_DOC_UPDATED_GASPEC">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">WAIT_GA_DRAFT</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_152d168</bpmn:incoming>
+      <bpmn:outgoing>Flow_061nml9</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_061nml9" sourceRef="WaitCivilDraftDocumentUpdatedId" targetRef="Gateway_1so1uwc" />
+    <bpmn:exclusiveGateway id="Gateway_1so1uwc" name="IsVaryJudgementAppMovedOffline ?">
+      <bpmn:incoming>Flow_061nml9</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ho04ze</bpmn:outgoing>
+      <bpmn:outgoing>Flow_15j5tee</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0ho04ze" name="Yes" sourceRef="Gateway_1so1uwc" targetRef="TriggerMainCaseToMoveOfflineId">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${(!empty flowFlags.VARY_JUDGE_GA_BY_RESP &amp;&amp; flowFlags.VARY_JUDGE_GA_BY_RESP)}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:serviceTask id="TriggerMainCaseToMoveOfflineId" name="Trigger Parent Case to move offline" camunda:type="external" camunda:topic="processGaCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">TRIGGER_MAIN_CASE_FROM_GA</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0ho04ze</bpmn:incoming>
+      <bpmn:outgoing>Flow_01ow93i</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_01ow93i" sourceRef="TriggerMainCaseToMoveOfflineId" targetRef="Gateway_0nb8bqq" />
+    <bpmn:sequenceFlow id="Flow_15j5tee" name="No" sourceRef="Gateway_1so1uwc" targetRef="Gateway_0nb8bqq">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${(empty flowFlags.VARY_JUDGE_GA_BY_RESP || !flowFlags.VARY_JUDGE_GA_BY_RESP)}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+  </bpmn:process>
+  <bpmn:message id="Message_0ttrrz3" name="UPLOAD_TRANSLATED_DOCUMENT_GA_SUMMARY_RESPONSE_DOC" />
+  <bpmn:error id="Error_1alq6sw" name="StartBusinessAbort" errorCode="ABORT" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="UPLOAD_TRANSLATED_DOCUMENT_GA_SUMMARY_RESPONSE_DOC">
+      <bpmndi:BPMNShape id="Event_1diii28_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="195" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="158" y="238" width="25" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0gt1863_di" bpmnElement="Activity_0gt1863">
+        <dc:Bounds x="230" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0nc34kd_di" bpmnElement="Event_0nc34kd">
+        <dc:Bounds x="262" y="92" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1cajp65" bpmnElement="AddDraftDocToMainCaseID">
+        <dc:Bounds x="390" y="173" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_07ek9xj_di" bpmnElement="Event_07ek9xj">
+        <dc:Bounds x="1602" y="195" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0eo8p2p_di" bpmnElement="Activity_0eo8p2p">
+        <dc:Bounds x="1440" y="173" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0pwnstm_di" bpmnElement="BulkPrintOrderRespondent">
+        <dc:Bounds x="1350" y="290" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_14xtsk2_di" bpmnElement="Gateway_14xtsk2" isMarkerVisible="true">
+        <dc:Bounds x="1185" y="188" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1gjfcvf_di" bpmnElement="BulkPrintOrderApplicant">
+        <dc:Bounds x="1040" y="300" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0nb8bqq_di" bpmnElement="Gateway_0nb8bqq" isMarkerVisible="true">
+        <dc:Bounds x="965" y="188" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1167" y="155" width="27" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0stc1rq" bpmnElement="WaitCivilDraftDocumentUpdatedId">
+        <dc:Bounds x="540" y="173" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1so1uwc_di" bpmnElement="Gateway_1so1uwc" isMarkerVisible="true">
+        <dc:Bounds x="685" y="188" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="667" y="158" width="86" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0hpx5j8" bpmnElement="TriggerMainCaseToMoveOfflineId">
+        <dc:Bounds x="790" y="173" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1p3emre_di" bpmnElement="Event_1p3emre">
+        <dc:Bounds x="262" y="152" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="297" y="133" width="27" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_13dgz5v_di" bpmnElement="Flow_13dgz5v">
+        <di:waypoint x="280" y="152" />
+        <di:waypoint x="280" y="128" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0g2t112_di" bpmnElement="Flow_0g2t112">
+        <di:waypoint x="188" y="213" />
+        <di:waypoint x="230" y="213" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07n1ssi_di" bpmnElement="Flow_07n1ssi">
+        <di:waypoint x="330" y="210" />
+        <di:waypoint x="390" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1u52am6_di" bpmnElement="Flow_1u52am6">
+        <di:waypoint x="1015" y="213" />
+        <di:waypoint x="1185" y="213" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1069" y="195" width="63" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06pv761_di" bpmnElement="Flow_06pv761">
+        <di:waypoint x="990" y="238" />
+        <di:waypoint x="990" y="340" />
+        <di:waypoint x="1040" y="340" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1007" y="273" width="65" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_05b0ay8_di" bpmnElement="Flow_05b0ay8">
+        <di:waypoint x="1235" y="213" />
+        <di:waypoint x="1440" y="213" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1316" y="195" width="78" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1o113vl_di" bpmnElement="Flow_1o113vl">
+        <di:waypoint x="1140" y="340" />
+        <di:waypoint x="1210" y="340" />
+        <di:waypoint x="1210" y="238" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0zobuvp_di" bpmnElement="Flow_0zobuvp">
+        <di:waypoint x="1210" y="238" />
+        <di:waypoint x="1210" y="340" />
+        <di:waypoint x="1350" y="340" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1220" y="273" width="80" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_152d168_di" bpmnElement="Flow_152d168">
+        <di:waypoint x="490" y="213" />
+        <di:waypoint x="540" y="213" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0xqrj4z_di" bpmnElement="Flow_0xqrj4z">
+        <di:waypoint x="1450" y="330" />
+        <di:waypoint x="1490" y="330" />
+        <di:waypoint x="1490" y="253" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_12hy528_di" bpmnElement="Flow_12hy528">
+        <di:waypoint x="1540" y="213" />
+        <di:waypoint x="1602" y="213" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_061nml9_di" bpmnElement="Flow_061nml9">
+        <di:waypoint x="640" y="213" />
+        <di:waypoint x="685" y="213" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ho04ze_di" bpmnElement="Flow_0ho04ze">
+        <di:waypoint x="735" y="213" />
+        <di:waypoint x="790" y="213" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="754" y="195" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_01ow93i_di" bpmnElement="Flow_01ow93i">
+        <di:waypoint x="890" y="213" />
+        <di:waypoint x="965" y="213" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_15j5tee_di" bpmnElement="Flow_15j5tee">
+        <di:waypoint x="710" y="238" />
+        <di:waypoint x="710" y="340" />
+        <di:waypoint x="990" y="340" />
+        <di:waypoint x="990" y="238" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="843" y="322" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/UploadTranslatedDocGaSummaryDocTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/UploadTranslatedDocGaSummaryDocTest.java
@@ -1,0 +1,157 @@
+package uk.gov.hmcts.reform.civil.bpmn;
+
+import org.camunda.bpm.engine.externaltask.ExternalTask;
+import org.camunda.bpm.engine.variable.VariableMap;
+import org.camunda.bpm.engine.variable.Variables;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static uk.gov.hmcts.reform.civil.bpmn.BpmnBaseGASpecTest.START_GA_BUSINESS_ACTIVITY;
+import static uk.gov.hmcts.reform.civil.bpmn.BpmnBaseGASpecTest.START_GA_BUSINESS_EVENT;
+
+public class UploadTranslatedDocGaSummaryDocTest extends BpmnBaseGAAfterPaymentTest {
+    public static final String END_BUSINESS_PROCESS = "END_BUSINESS_PROCESS_GASPEC";
+    private static final String START_BUSINESS_TOPIC = "START_GA_BUSINESS_PROCESS";
+    private static final String WELSH_ENABLED = "WELSH_ENABLED";
+    private static final String LIP_APPLICANT = "LIP_APPLICANT";
+    private static final String LIP_RESPONDENT = "LIP_RESPONDENT";
+    public static final String UPDATE_FROM_GA_CASE_EVENT = "updateFromGACaseEvent";
+    private static final String ADD_PDF_EVENT = "ADD_PDF_TO_MAIN_CASE";
+    private static final String ADD_PDF_ID = "AddDraftDocToMainCaseID";
+    public static final String PROCESS_EXTERNAL_CASE_EVENT = "processExternalCaseEventGASpec";
+    private static final String NOTIFYING_RESPONDENTS_EVENT = "NOTIFY_GENERAL_APPLICATION_RESPONDENT";
+    private static final String GENERAL_APPLICATION_NOTIFYING_ID = "GeneralApplicationNotifying";
+    public static final String APPLICATION_PROCESS_EVENT_GA_SPEC = "applicationProcessCaseEventGASpec";
+    private static final String UPDATE_DASHBOARD_NOTIFICATIONS = "UPDATE_GA_DASHBOARD_NOTIFICATION";
+    private static final String CREATE_APPLICATION_SUBMITTED_DASHBOARD_NOTIFICATION_FOR_RESPONDENT_EVENT = "CREATE_APPLICATION_SUBMITTED_DASHBOARD_NOTIFICATION_FOR_RESPONDENT";
+    private static final String CREATE_APPLICATION_SUBMITTED_DASHBOARD_NOTIFICATION_FOR_RESPONDENT_ACTIVITY_ID = "respondentDashboardNotification";
+
+    private static final String UPDATE_DASHBOARD_NOTIFICATIONS_ID = "UpdateDashboardNotifications";
+    private static final String UPDATE_CLAIMANT_DASHBOARD_GA_EVENT = "UPDATE_CLAIMANT_TASK_LIST_GA";
+    private static final String UPDATE_RESPONDENT_DASHBOARD_GA_EVENT = "UPDATE_RESPONDENT_TASK_LIST_GA";
+
+    private static final String APPLICATION_EVENT_GASPEC = "applicationEventGASpec";
+    private static final String GENERAL_APPLICATION_CLAIMANT_TASK_LIST_ID = "GeneralApplicationClaimantTaskList";
+    private static final String GENERAL_APPLICATION_RESPONDENT_TASK_LIST_ID = "GeneralApplicationRespondentTaskList";
+    public static final String NOTIFY_EVENT = "processExternalCaseEventGASpec";
+
+    public UploadTranslatedDocGaSummaryDocTest() {
+        super("upload_translated_document_ga_summary_doc.bpmn", "UPLOAD_TRANSLATED_DOCUMENT_GA_SUMMARY_DOC");
+    }
+
+
+    @ParameterizedTest
+    @CsvSource({"false,false", "true,false", "true,true", "false,true"})
+    void shouldResumePausedTaskAfterUploadingTranslatedDocument(boolean isLipApplicant, boolean isLipRespondent) {
+        VariableMap variables = Variables.createVariables();
+        variables.put("flowFlags", Map.of(
+            WELSH_ENABLED, "true",
+            LIP_APPLICANT, isLipApplicant,
+            LIP_RESPONDENT , isLipRespondent));
+
+        //assert process has started
+        assertFalse(processInstance.isEnded());
+        //complete the start business process
+        ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
+        assertCompleteExternalTask(
+            startBusiness,
+            START_BUSINESS_TOPIC,
+            START_GA_BUSINESS_EVENT,
+            START_GA_BUSINESS_ACTIVITY,
+            variables
+        );
+
+        //Complete add pdf to main case event
+        ExternalTask addDocumentToMainCase = assertNextExternalTask(UPDATE_FROM_GA_CASE_EVENT);
+        assertCompleteExternalTask(
+            addDocumentToMainCase,
+            UPDATE_FROM_GA_CASE_EVENT,
+            ADD_PDF_EVENT,
+            ADD_PDF_ID,
+            variables
+        );
+
+        //notify respondents
+        ExternalTask notifyRespondents = assertNextExternalTask(PROCESS_EXTERNAL_CASE_EVENT);
+        assertCompleteExternalTask(
+            notifyRespondents,
+            PROCESS_EXTERNAL_CASE_EVENT,
+            NOTIFYING_RESPONDENTS_EVENT,
+            GENERAL_APPLICATION_NOTIFYING_ID,
+            variables
+        );
+
+        if (isLipApplicant) {
+            //update dashboard
+            ExternalTask updateCuiClaimantDashboard = assertNextExternalTask(APPLICATION_PROCESS_EVENT_GA_SPEC);
+            assertCompleteExternalTask(
+                updateCuiClaimantDashboard,
+                APPLICATION_PROCESS_EVENT_GA_SPEC,
+                UPDATE_DASHBOARD_NOTIFICATIONS,
+                UPDATE_DASHBOARD_NOTIFICATIONS_ID,
+                variables
+            );
+
+            //post translated document to LiP applicant
+            ExternalTask bulkPrintApplicantTask = assertNextExternalTask(NOTIFY_EVENT);
+            assertCompleteExternalTask(
+                bulkPrintApplicantTask,
+                NOTIFY_EVENT,
+                "SEND_TRANSLATED_ORDER_TO_LIP_APPLICANT",
+                "BulkPrintOrderApplicant",
+                variables
+            );
+        }
+
+        if (isLipRespondent) {
+            //update dashboard
+            ExternalTask updateCuiRespondentDashboard = assertNextExternalTask(APPLICATION_PROCESS_EVENT_GA_SPEC);
+            assertCompleteExternalTask(
+                updateCuiRespondentDashboard,
+                APPLICATION_PROCESS_EVENT_GA_SPEC,
+                CREATE_APPLICATION_SUBMITTED_DASHBOARD_NOTIFICATION_FOR_RESPONDENT_EVENT,
+                CREATE_APPLICATION_SUBMITTED_DASHBOARD_NOTIFICATION_FOR_RESPONDENT_ACTIVITY_ID,
+                variables
+            );
+
+            ExternalTask bulkPrintRespondentTask = assertNextExternalTask(NOTIFY_EVENT);
+            assertCompleteExternalTask(
+                bulkPrintRespondentTask,
+                NOTIFY_EVENT,
+                "SEND_TRANSLATED_ORDER_TO_LIP_RESPONDENT",
+                "BulkPrintOrderRespondent",
+                variables
+            );
+        }
+
+        ExternalTask endBusinessProcess = assertNextExternalTask(END_BUSINESS_PROCESS);
+        completeBusinessProcess(endBusinessProcess);
+
+        if (isLipApplicant || isLipRespondent) {
+            //update dashboard
+            ExternalTask updateCuiClaimantDashboard = assertNextExternalTask(APPLICATION_EVENT_GASPEC);
+            assertCompleteExternalTask(
+                updateCuiClaimantDashboard,
+                APPLICATION_EVENT_GASPEC,
+                UPDATE_CLAIMANT_DASHBOARD_GA_EVENT,
+                GENERAL_APPLICATION_CLAIMANT_TASK_LIST_ID,
+                variables
+            );
+
+            ExternalTask updateCuiDefendantDashboard = assertNextExternalTask(APPLICATION_EVENT_GASPEC);
+            assertCompleteExternalTask(
+                updateCuiDefendantDashboard,
+                APPLICATION_EVENT_GASPEC,
+                UPDATE_RESPONDENT_DASHBOARD_GA_EVENT,
+                GENERAL_APPLICATION_RESPONDENT_TASK_LIST_ID,
+                variables
+            );
+        }
+
+        assertNoExternalTasksLeft();
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/UploadTranslatedGaResponseSumDocTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/UploadTranslatedGaResponseSumDocTest.java
@@ -1,0 +1,137 @@
+package uk.gov.hmcts.reform.civil.bpmn;
+
+import org.camunda.bpm.engine.externaltask.ExternalTask;
+import org.camunda.bpm.engine.variable.VariableMap;
+import org.camunda.bpm.engine.variable.Variables;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.Map;
+
+public class UploadTranslatedGaResponseSumDocTest extends BpmnBaseGAAfterPaymentTest {
+    private static final String VARY_JUDGE_GA_BY_RESP = "VARY_JUDGE_GA_BY_RESP";
+    private static final String LIP_APPLICANT = "LIP_APPLICANT";
+    private static final String  LIP_RESPONDENT = "LIP_RESPONDENT";
+    private static final String TRIGGER_MAIN_CASE_ID = "TriggerMainCaseToMoveOfflineId";
+    private static final String TRIGGER_MAIN_CASE_TOPIC = "processGaCaseEvent";
+    private static final String TRIGGER_MAIN_CASE_EVENT = "TRIGGER_MAIN_CASE_FROM_GA";
+    public static final String UPDATE_FROM_GA_CASE_EVENT = "updateFromGACaseEvent";
+    private static final String ADD_PDF_EVENT = "ADD_PDF_TO_MAIN_CASE";
+    private static final String ADD_PDF_ID = "AddDraftDocToMainCaseID";
+    private static final String WAIT_PDF_UPDATE_ID = "WaitCivilDraftDocumentUpdatedId";
+    private static final String WAIT_PDF_UPDATE_TOPIC = "WAIT_CIVIL_DOC_UPDATED_GASPEC";
+    private static final String WAIT_PDF_UPDATE_EVENT = "WAIT_GA_DRAFT";
+    public static final String NOTIFY_EVENT = "processExternalCaseEventGASpec";
+    private static final String APPLICATION_EVENT_GA_SPEC = "applicationEventGASpec";
+    private static final String GENERAL_APPLICATION_CLAIMANT_TASK_LIST_ID = "GeneralApplicationClaimantTaskList";
+    private static final String GENERAL_APPLICATION_RESPONDENT_TASK_LIST_ID = "GeneralApplicationRespondentTaskList";
+    private static final String UPDATE_CLAIMANT_DASHBOARD_GA_EVENT = "UPDATE_CLAIMANT_TASK_LIST_GA";
+    private static final String UPDATE_RESPONDENT_DASHBOARD_GA_EVENT = "UPDATE_RESPONDENT_TASK_LIST_GA";
+
+    public UploadTranslatedGaResponseSumDocTest() {
+        super("upload_translated_document_ga_summary_response_doc.bpmn", "UPLOAD_TRANSLATED_DOCUMENT_GA_SUMMARY_RESPONSE_DOC");
+    }
+
+    @ParameterizedTest
+    @CsvSource({"false, false, true", "true, true, false", "true, true, true"})
+    void shouldUnPauseTheTaskAfterUploadingTranslatedDocument(boolean isVaryJudgementAppTakenOffline, boolean isLipApplicant, boolean isLipRespondent) {
+        VariableMap variables = Variables.createVariables();
+        variables.put("flowFlags", Map.of(
+            VARY_JUDGE_GA_BY_RESP, isVaryJudgementAppTakenOffline,
+            LIP_APPLICANT , isLipApplicant,
+            LIP_RESPONDENT, isLipRespondent));
+
+        //complete the start business process
+        ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
+        assertCompleteExternalTask(
+            startBusiness,
+            START_BUSINESS_TOPIC,
+            START_BUSINESS_EVENT,
+            START_BUSINESS_ACTIVITY,
+            variables
+        );
+
+        //Complete add pdf to main case event
+        ExternalTask addDocumentToMainCase = assertNextExternalTask(UPDATE_FROM_GA_CASE_EVENT);
+        assertCompleteExternalTask(
+            addDocumentToMainCase,
+            UPDATE_FROM_GA_CASE_EVENT,
+            ADD_PDF_EVENT,
+            ADD_PDF_ID,
+            variables
+        );
+
+        //Complete add pdf to main case event
+        ExternalTask waitMainCaseDocUpdated = assertNextExternalTask(WAIT_PDF_UPDATE_TOPIC);
+        assertCompleteExternalTask(
+            waitMainCaseDocUpdated,
+            WAIT_PDF_UPDATE_TOPIC,
+            WAIT_PDF_UPDATE_EVENT,
+            WAIT_PDF_UPDATE_ID,
+            variables
+        );
+
+        if (isVaryJudgementAppTakenOffline) {
+            ExternalTask triggerMainCase = assertNextExternalTask(TRIGGER_MAIN_CASE_TOPIC);
+            assertCompleteExternalTask(
+                triggerMainCase,
+                TRIGGER_MAIN_CASE_TOPIC,
+                TRIGGER_MAIN_CASE_EVENT,
+                TRIGGER_MAIN_CASE_ID,
+                variables
+            );
+
+        }
+
+        if (isLipApplicant) {
+            //post translated document to LiP applicant
+            ExternalTask bulkPrintApplicantTask = assertNextExternalTask(NOTIFY_EVENT);
+            assertCompleteExternalTask(
+                bulkPrintApplicantTask,
+                NOTIFY_EVENT,
+                "SEND_TRANSLATED_ORDER_TO_LIP_APPLICANT",
+                "BulkPrintOrderApplicant",
+                variables
+            );
+        }
+
+        if (isLipRespondent) {
+             ExternalTask bulkPrintRespondentTask = assertNextExternalTask(NOTIFY_EVENT);
+            assertCompleteExternalTask(
+                bulkPrintRespondentTask,
+                NOTIFY_EVENT,
+                "SEND_TRANSLATED_ORDER_TO_LIP_RESPONDENT",
+                "BulkPrintOrderRespondent",
+                variables
+            );
+        }
+
+        //end business process
+        ExternalTask endBusinessProcess = assertNextExternalTask(END_BUSINESS_PROCESS);
+        completeBusinessProcess(endBusinessProcess);
+
+        if (isLipApplicant || isLipRespondent) {
+            //update dashboard
+            ExternalTask updateCuiClaimantDashboard = assertNextExternalTask(APPLICATION_EVENT_GA_SPEC);
+            assertCompleteExternalTask(
+                updateCuiClaimantDashboard,
+                APPLICATION_EVENT_GA_SPEC,
+                UPDATE_CLAIMANT_DASHBOARD_GA_EVENT,
+                GENERAL_APPLICATION_CLAIMANT_TASK_LIST_ID,
+                variables
+            );
+
+            ExternalTask updateCuiDefendantDashboard = assertNextExternalTask(APPLICATION_EVENT_GA_SPEC);
+            assertCompleteExternalTask(
+                updateCuiDefendantDashboard,
+                APPLICATION_EVENT_GA_SPEC,
+                UPDATE_RESPONDENT_DASHBOARD_GA_EVENT,
+                GENERAL_APPLICATION_RESPONDENT_TASK_LIST_ID,
+                variables
+            );
+        }
+
+        assertNoExternalTasksLeft();
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-16916


### Change description ###
Implemented code changes to un-pause tasks and trigger state updates following the upload of translated documents for both the Application Summary and Response to Application Summary document

![image](https://github.com/user-attachments/assets/de702638-e9a3-4d27-9403-d6fa7e90f808)
![image](https://github.com/user-attachments/assets/485731d3-fdc8-449c-b0b2-472ce96bd05f)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
