### PR TITLE
CIV-17399 Claim is paused for part admit where repayment amount is accepted by claimant

### DIFF
--- a/src/main/resources/camunda/claimant_response_cui.bpmn
+++ b/src/main/resources/camunda/claimant_response_cui.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_18h9iji" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_18h9iji" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.5.1">
   <bpmn:process id="CLAIMANT_RESPONSE_CUI_PROCESS_ID" name="Claimant response cui process" isExecutable="true" camunda:historyTimeToLive="P90D">
     <bpmn:startEvent id="CLRCUI_StartEvent_1" name="start">
       <bpmn:outgoing>Flow_0uwkh9v</bpmn:outgoing>
@@ -76,7 +76,7 @@
       <bpmn:incoming>Flow_15z0dwe</bpmn:incoming>
       <bpmn:outgoing>Flow_0v6zgri</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0v6zgri" sourceRef="ClaimantConfirmProceedNotifyParties" targetRef="Gateway_12dmvul" />
+    <bpmn:sequenceFlow id="Flow_0v6zgri" sourceRef="ClaimantConfirmProceedNotifyParties" targetRef="Gateway_0t6rvya" />
     <bpmn:sequenceFlow id="Flow_FullAdmitPayImmediatly" name="Full admit" sourceRef="Gateway_RESPONSE_FLOW" targetRef="ClaimantConfirmProceedNotifyParties">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.FULL_ADMISSION"||flowState == "MAIN.FULL_ADMIT_PAY_IMMEDIATELY"||flowState == "MAIN.FULL_ADMIT_PAY_IMMEDIATELY"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
@@ -103,6 +103,7 @@
     <bpmn:exclusiveGateway id="Gateway_RPA_FLOW">
       <bpmn:incoming>Flow_0pcu8vp</bpmn:incoming>
       <bpmn:incoming>Flow_19cet4s</bpmn:incoming>
+      <bpmn:incoming>Flow_0o0wfdr</bpmn:incoming>
       <bpmn:outgoing>Flow_089b2nt</bpmn:outgoing>
       <bpmn:outgoing>Flow_0xsst33</bpmn:outgoing>
       <bpmn:outgoing>Flow_0ia7tek</bpmn:outgoing>
@@ -426,7 +427,7 @@
     <bpmn:sequenceFlow id="Flow_1d396po" sourceRef="PostPINInLetterLIPDefendant" targetRef="Gateway_08rlyk5" />
     <bpmn:exclusiveGateway id="Gateway_12dmvul">
       <bpmn:incoming>Flow_1msvhgp</bpmn:incoming>
-      <bpmn:incoming>Flow_0v6zgri</bpmn:incoming>
+      <bpmn:incoming>Flow_0z3qqn2</bpmn:incoming>
       <bpmn:outgoing>Flow_0x1cuga</bpmn:outgoing>
       <bpmn:outgoing>Flow_0qomvto</bpmn:outgoing>
     </bpmn:exclusiveGateway>
@@ -476,6 +477,17 @@
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_1b3kpvc" name="yes" sourceRef="Gateway_0yyi3a3" targetRef="Generate_LIP_Claimant_MD">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${(!empty flowFlags.WELSH_ENABLED &amp;&amp; flowFlags.WELSH_ENABLED) &amp;&amp; ((!empty flowFlags.CLAIM_ISSUE_BILINGUAL &amp;&amp; flowFlags.CLAIM_ISSUE_BILINGUAL) || (!empty flowFlags.RESPONDENT_RESPONSE_LANGUAGE_IS_BILINGUAL &amp;&amp; flowFlags.RESPONDENT_RESPONSE_LANGUAGE_IS_BILINGUAL))}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:exclusiveGateway id="Gateway_0t6rvya">
+      <bpmn:incoming>Flow_0v6zgri</bpmn:incoming>
+      <bpmn:outgoing>Flow_0z3qqn2</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0o0wfdr</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0z3qqn2" name="check for location update when admission document not generated" sourceRef="Gateway_0t6rvya" targetRef="Gateway_12dmvul">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!(flowState == "MAIN.FULL_ADMIT_AGREE_REPAYMENT"  || flowState == "MAIN.PART_ADMIT_AGREE_REPAYMENT"  ||(flowState == "MAIN.FULL_ADMIT_REJECT_REPAYMENT" || flowState == "MAIN.PART_ADMIT_REJECT_REPAYMENT")  &amp;&amp; ((!empty flowFlags.JO_ONLINE_LIVE_ENABLED &amp;&amp; flowFlags.JO_ONLINE_LIVE_ENABLED) &amp;&amp; (!empty flowFlags.LIP_JUDGMENT_ADMISSION &amp;&amp; flowFlags.LIP_JUDGMENT_ADMISSION)))}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0o0wfdr" name="judgement admission document generated (no need to pause)" sourceRef="Gateway_0t6rvya" targetRef="Gateway_RPA_FLOW">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.FULL_ADMIT_AGREE_REPAYMENT"  || flowState == "MAIN.PART_ADMIT_AGREE_REPAYMENT" ||(flowState == "MAIN.FULL_ADMIT_REJECT_REPAYMENT" || flowState == "MAIN.PART_ADMIT_REJECT_REPAYMENT")  &amp;&amp; ((!empty flowFlags.JO_ONLINE_LIVE_ENABLED &amp;&amp; flowFlags.JO_ONLINE_LIVE_ENABLED) &amp;&amp; (!empty flowFlags.LIP_JUDGMENT_ADMISSION &amp;&amp; flowFlags.LIP_JUDGMENT_ADMISSION))}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
   </bpmn:process>
   <bpmn:message id="Message_0ttrrz3" name="CLAIMANT_RESPONSE_CUI" />
@@ -654,6 +666,9 @@
           <dc:Bounds x="678" y="953" width="64" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0t6rvya_di" bpmnElement="Gateway_0t6rvya" isMarkerVisible="true">
+        <dc:Bounds x="1085" y="478" width="50" height="50" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0yhzfu9_di" bpmnElement="Event_0yhzfu9">
         <dc:Bounds x="272" y="445" width="36" height="36" />
       </bpmndi:BPMNShape>
@@ -675,8 +690,7 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0v6zgri_di" bpmnElement="Flow_0v6zgri">
         <di:waypoint x="1020" y="503" />
-        <di:waypoint x="1110" y="503" />
-        <di:waypoint x="1110" y="605" />
+        <di:waypoint x="1085" y="503" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0rwqfhd_di" bpmnElement="Flow_FullAdmitPayImmediatly">
         <di:waypoint x="465" y="503" />
@@ -1026,6 +1040,22 @@
         <di:waypoint x="1100" y="1040" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="892" y="1080" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0z3qqn2_di" bpmnElement="Flow_0z3qqn2">
+        <di:waypoint x="1110" y="528" />
+        <di:waypoint x="1110" y="605" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1031" y="527" width="78" height="66" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0o0wfdr_di" bpmnElement="Flow_0o0wfdr">
+        <di:waypoint x="1110" y="478" />
+        <di:waypoint x="1110" y="310" />
+        <di:waypoint x="1530" y="310" />
+        <di:waypoint x="1530" y="478" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1203" y="237" width="74" height="66" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ClaimantResponseCuiTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ClaimantResponseCuiTest.java
@@ -183,7 +183,6 @@ public class ClaimantResponseCuiTest extends BpmnBaseTest {
 
         generateJudgmentByAdmissionPdf();
         notifyPartiesClaimantConfirmsToProceed();
-        generateDQPdf();
         proceedCaseOffline();
         notifyRPACaseHandledOffline();
         generateClaimantDashboardNotificationForCCJClaimantResponse();
@@ -218,7 +217,6 @@ public class ClaimantResponseCuiTest extends BpmnBaseTest {
 
         generateJudgmentByAdmissionPdf();
         notifyPartiesClaimantConfirmsToProceed();
-        generateDQPdf();
         proceedCaseOffline();
         notifyRPACaseHandledOffline();
         generateClaimantDashboardNotificationForCCJClaimantResponse();
@@ -658,7 +656,6 @@ public class ClaimantResponseCuiTest extends BpmnBaseTest {
         );
         generateJudgmentByAdmissionPdf();
         notifyPartiesClaimantConfirmsToProceed();
-        generateDQPdf();
         updateClaimantClaimState();
         sendJudgmentToCjesService();
         generateJudgmentByAdmissionClaimantDocument();
@@ -700,7 +697,6 @@ public class ClaimantResponseCuiTest extends BpmnBaseTest {
         );
         generateJudgmentByAdmissionPdf();
         notifyPartiesClaimantConfirmsToProceed();
-        generateDQPdf();
         updateClaimantClaimState();
         sendJudgmentToCjesService();
         generateJudgmentByAdmissionClaimantDocument();
@@ -742,7 +738,6 @@ public class ClaimantResponseCuiTest extends BpmnBaseTest {
         );
         generateJudgmentByAdmissionPdf();
         notifyPartiesClaimantConfirmsToProceed();
-        generateDQPdf();
         updateClaimantClaimState();
         sendJudgmentToCjesService();
         generateJudgmentByAdmissionClaimantDocument();


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x ] commit messages are meaningful and follow good commit message guidelines
- [x ] README and other documentation has been updated / added (if needed)
- [x ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-17399

### Change description ###

Where a Judgment by Admission document is generated and one of the parties is Welsh, then the claim is still being paused for translation of DQs even though no DQs are generated. The scope of this ticket is to fix this.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
