### PR TITLE
CIV-17589 - GA not moving offline when Main Claim moves offline post NoC

### DIFF
--- a/src/main/resources/camunda/apply_noc_decision_defendant_lip.bpmn
+++ b/src/main/resources/camunda/apply_noc_decision_defendant_lip.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1xagno6" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1xagno6" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.33.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
   <bpmn:collaboration id="Defendant">
     <bpmn:extensionElements>
       <camunda:properties>
@@ -25,43 +25,6 @@
       <bpmn:outgoing>Flow_GA_Not_Enabled</bpmn:outgoing>
       <bpmn:outgoing>Flow_GA_Enabled</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:serviceTask id="defendantLipApplicationOfflineDashboardNotification" name="Dashboard Notification For Application Offline Defendant" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">CREATE_DASHBOARD_NOTIFICATION_APPLICATION_PROCEED_OFFLINE_DEFENDANT</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0rmhi4k</bpmn:incoming>
-      <bpmn:outgoing>Flow_1yhff7r</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:serviceTask id="claimantLipApplicationOfflineDashboardNotification" name="Dashboard Notification For Application Offline Claimant" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">CREATE_DASHBOARD_NOTIFICATION_APPLICATION_PROCEED_OFFLINE_CLAIMANT</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_GA_Enabled</bpmn:incoming>
-      <bpmn:outgoing>Flow_0rmhi4k</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:serviceTask id="CreateClaimantDashboardNotificationDefendantNoc" name="Create Dashboard Notification Claimant 1" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">CREATE_CLAIMANT_DASHBOARD_NOTIFICATION_FOR_DEFENDANT_NOC</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_GA_Not_Enabled</bpmn:incoming>
-      <bpmn:incoming>Flow_1yhff7r</bpmn:incoming>
-      <bpmn:outgoing>Flow_1tclzid</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:serviceTask id="NotifyRoboticsOnCaseHandedOffline" name="Notify RPA on case handed offline" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_RPA_ON_CASE_HANDED_OFFLINE</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1tclzid</bpmn:incoming>
-      <bpmn:outgoing>Flow_0rz35k4</bpmn:outgoing>
-    </bpmn:serviceTask>
     <bpmn:exclusiveGateway id="Gateway_02x3bwe" name="NOC for Lip Defendant enabled">
       <bpmn:incoming>Flow_08bhmdx</bpmn:incoming>
       <bpmn:outgoing>Flow_0lzi8gi</bpmn:outgoing>
@@ -207,7 +170,7 @@
     <bpmn:sequenceFlow id="Flow_GA_Not_Enabled" name="GA Not Enabled" sourceRef="Gateway_0wjzkke" targetRef="CreateClaimantDashboardNotificationDefendantNoc">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${empty flowFlags.GENERAL_APPLICATION_ENABLED || !flowFlags.GENERAL_APPLICATION_ENABLED}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_GA_Enabled" name="GA Enabled" sourceRef="Gateway_0wjzkke" targetRef="claimantLipApplicationOfflineDashboardNotification">
+    <bpmn:sequenceFlow id="Flow_GA_Enabled" name="GA Enabled" sourceRef="Gateway_0wjzkke" targetRef="UpdateGeneralApplicationStatus">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.GENERAL_APPLICATION_ENABLED &amp;&amp; flowFlags.GENERAL_APPLICATION_ENABLED}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_0rmhi4k" sourceRef="claimantLipApplicationOfflineDashboardNotification" targetRef="defendantLipApplicationOfflineDashboardNotification" />
@@ -258,6 +221,63 @@
     <bpmn:sequenceFlow id="Flow_0rvh8ne" name="Yes" sourceRef="Gateway_0eccios" targetRef="ResetLanguagePreferenceAfterNoC">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.WELSH_ENABLED &amp;&amp; flowFlags.WELSH_ENABLED}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
+    <bpmn:serviceTask id="UpdateGeneralApplicationStatus" name="Update General Application Status" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">TRIGGER_APPLICATION_PROCEEDS_IN_HERITAGE</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_GA_Enabled</bpmn:incoming>
+      <bpmn:outgoing>Flow_13fy240</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_13fy240" sourceRef="UpdateGeneralApplicationStatus" targetRef="UpdateClaimWithApplicationStatus" />
+    <bpmn:serviceTask id="NotifyRoboticsOnCaseHandedOffline" name="Notify RPA on case handed offline" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_RPA_ON_CASE_HANDED_OFFLINE</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1tclzid</bpmn:incoming>
+      <bpmn:outgoing>Flow_0rz35k4</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="CreateClaimantDashboardNotificationDefendantNoc" name="Create Dashboard Notification Claimant 1" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">CREATE_CLAIMANT_DASHBOARD_NOTIFICATION_FOR_DEFENDANT_NOC</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_GA_Not_Enabled</bpmn:incoming>
+      <bpmn:incoming>Flow_1yhff7r</bpmn:incoming>
+      <bpmn:outgoing>Flow_1tclzid</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="defendantLipApplicationOfflineDashboardNotification" name="Dashboard Notification For Application Offline Defendant" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">CREATE_DASHBOARD_NOTIFICATION_APPLICATION_PROCEED_OFFLINE_DEFENDANT</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0rmhi4k</bpmn:incoming>
+      <bpmn:outgoing>Flow_1yhff7r</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="claimantLipApplicationOfflineDashboardNotification" name="Dashboard Notification For Application Offline Claimant" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">CREATE_DASHBOARD_NOTIFICATION_APPLICATION_PROCEED_OFFLINE_CLAIMANT</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_158ygxi</bpmn:incoming>
+      <bpmn:outgoing>Flow_0rmhi4k</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="UpdateClaimWithApplicationStatus" name="Update Claim with General Application Status" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">APPLICATION_OFFLINE_UPDATE_CLAIM</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_13fy240</bpmn:incoming>
+      <bpmn:outgoing>Flow_158ygxi</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_158ygxi" sourceRef="UpdateClaimWithApplicationStatus" targetRef="claimantLipApplicationOfflineDashboardNotification" />
   </bpmn:process>
   <bpmn:message id="Message_14dl5pe" name="APPLY_NOC_DECISION_DEFENDANT_LIP" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
@@ -272,21 +292,6 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0wjzkke_di" bpmnElement="Gateway_0wjzkke" isMarkerVisible="true">
         <dc:Bounds x="1796" y="625" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0w5znbg" bpmnElement="defendantLipApplicationOfflineDashboardNotification">
-        <dc:Bounds x="2071" y="610" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1rtq8df" bpmnElement="claimantLipApplicationOfflineDashboardNotification">
-        <dc:Bounds x="1931" y="610" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_01op09a_di" bpmnElement="CreateClaimantDashboardNotificationDefendantNoc">
-        <dc:Bounds x="2071" y="460" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1kdqyo6_di" bpmnElement="NotifyRoboticsOnCaseHandedOffline">
-        <dc:Bounds x="2261" y="460" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_02x3bwe_di" bpmnElement="Gateway_02x3bwe" isMarkerVisible="true">
         <dc:Bounds x="1656" y="275" width="50" height="50" />
@@ -375,6 +380,27 @@
         <dc:Bounds x="1410" y="260" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UpdateGeneralApplicationStatus_di" bpmnElement="UpdateGeneralApplicationStatus">
+        <dc:Bounds x="1900" y="610" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1kdqyo6_di" bpmnElement="NotifyRoboticsOnCaseHandedOffline">
+        <dc:Bounds x="2480" y="470" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_01op09a_di" bpmnElement="CreateClaimantDashboardNotificationDefendantNoc">
+        <dc:Bounds x="2290" y="470" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0w5znbg" bpmnElement="defendantLipApplicationOfflineDashboardNotification">
+        <dc:Bounds x="2290" y="610" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1rtq8df" bpmnElement="claimantLipApplicationOfflineDashboardNotification">
+        <dc:Bounds x="2160" y="610" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UpdateClaimWithApplicationStatus_di" bpmnElement="UpdateClaimWithApplicationStatus">
+        <dc:Bounds x="2030" y="610" width="100" height="80" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_056imgr_di" bpmnElement="Event_0rh0701">
         <dc:Bounds x="392" y="242" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -412,34 +438,34 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_09ya9uk_di" bpmnElement="Flow_GA_Not_Enabled">
         <di:waypoint x="1821" y="625" />
-        <di:waypoint x="1821" y="500" />
-        <di:waypoint x="2071" y="500" />
+        <di:waypoint x="1821" y="510" />
+        <di:waypoint x="2290" y="510" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1901" y="483" width="79" height="14" />
+          <dc:Bounds x="2007" y="493" width="79" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0sru8ot_di" bpmnElement="Flow_GA_Enabled">
         <di:waypoint x="1846" y="650" />
-        <di:waypoint x="1931" y="650" />
+        <di:waypoint x="1900" y="650" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1845" y="663" width="59" height="14" />
+          <dc:Bounds x="1830" y="673" width="59" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0rmhi4k_di" bpmnElement="Flow_0rmhi4k">
-        <di:waypoint x="2031" y="650" />
-        <di:waypoint x="2071" y="650" />
+        <di:waypoint x="2260" y="650" />
+        <di:waypoint x="2290" y="650" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1yhff7r_di" bpmnElement="Flow_1yhff7r">
-        <di:waypoint x="2121" y="610" />
-        <di:waypoint x="2121" y="540" />
+        <di:waypoint x="2340" y="610" />
+        <di:waypoint x="2340" y="550" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1tclzid_di" bpmnElement="Flow_1tclzid">
-        <di:waypoint x="2171" y="500" />
-        <di:waypoint x="2261" y="500" />
+        <di:waypoint x="2390" y="510" />
+        <di:waypoint x="2480" y="510" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0rz35k4_di" bpmnElement="Flow_0rz35k4">
-        <di:waypoint x="2361" y="500" />
-        <di:waypoint x="2660" y="500" />
+        <di:waypoint x="2580" y="510" />
+        <di:waypoint x="2660" y="510" />
         <di:waypoint x="2660" y="330" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_08bhmdx_di" bpmnElement="Flow_08bhmdx">
@@ -573,6 +599,14 @@
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1384" y="282" width="19" height="14" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13fy240_di" bpmnElement="Flow_13fy240">
+        <di:waypoint x="2000" y="650" />
+        <di:waypoint x="2030" y="650" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_158ygxi_di" bpmnElement="Flow_158ygxi">
+        <di:waypoint x="2130" y="650" />
+        <di:waypoint x="2160" y="650" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ApplyNocDecisionDefendantLipTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ApplyNocDecisionDefendantLipTest.java
@@ -25,6 +25,10 @@ public class ApplyNocDecisionDefendantLipTest extends BpmnBaseTest {
         = "CREATE_CLAIMANT_DASHBOARD_NOTIFICATION_FOR_DEFENDANT_NOC";
     private static final String CREATE_CLAIMANT_DASHBOARD_NOTIFICATION_FOR_DEFENDANT_NOC_ACTIVITY_ID
         = "CreateClaimantDashboardNotificationDefendantNoc";
+    public static final String TRIGGER_APPLICATION_PROCEEDS_IN_HERITAGE = "TRIGGER_APPLICATION_PROCEEDS_IN_HERITAGE";
+    private static final String APPLICATION_PROCEEDS_IN_HERITAGE_ACTIVITY_ID = "UpdateGeneralApplicationStatus";
+    public static final String APPLICATION_OFFLINE_UPDATE_CLAIM = "APPLICATION_OFFLINE_UPDATE_CLAIM";
+    private static final String APPLICATION_OFFLINE_UPDATE_CLAIM_ACTIVITY_ID = "UpdateClaimWithApplicationStatus";
 
     public ApplyNocDecisionDefendantLipTest() {
         super("apply_noc_decision_defendant_lip.bpmn", PROCESS_ID);
@@ -511,6 +515,133 @@ public class ApplyNocDecisionDefendantLipTest extends BpmnBaseTest {
             PROCESS_CASE_EVENT,
             PROCEEDS_IN_HERITAGE_SYSTEM,
             PROCEEDS_IN_HERITAGE_SYSTEM_ACTIVITY_ID
+        );
+
+        //complete Dashboard notification
+        ExternalTask dashboardNotificationTask = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            dashboardNotificationTask,
+            PROCESS_CASE_EVENT,
+            CREATE_CLAIMANT_DASHBOARD_NOTIFICATION_FOR_DEFENDANT_NOC,
+            CREATE_CLAIMANT_DASHBOARD_NOTIFICATION_FOR_DEFENDANT_NOC_ACTIVITY_ID
+        );
+
+        //complete the Robotics notification
+        ExternalTask forRobotics = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            forRobotics,
+            PROCESS_CASE_EVENT,
+            NOTIFY_RPA_ON_CASE_HANDED_OFFLINE,
+            NOTIFY_RPA_ON_CASE_HANDED_OFFLINE_ACTIVITY_ID
+        );
+
+        //end business process
+        ExternalTask endBusinessProcess = assertNextExternalTask(END_BUSINESS_PROCESS);
+        completeBusinessProcess(endBusinessProcess);
+
+        assertNoExternalTasksLeft();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"MAIN.FULL_ADMISSION", "MAIN.PART_ADMISSION"})
+    void shouldMoveTheCaseOffline_MovedGAOfflineToo(String responseType) {
+        VariableMap variables = Variables.createVariables();
+        variables.putValue("flowState", responseType);
+        variables.put(FLOW_FLAGS, Map.of(
+            LIP_CASE, true,
+            DEFENDANT_NOC_ONLINE, true,
+            JBA_ISSUED_BEFORE_NOC, true,
+            CLAIM_STATE_DURING_NOC, false,
+            GENERAL_APPLICATION_ENABLED , true));
+
+        //assert process has started
+        assertFalse(processInstance.isEnded());
+        //complete the start business process
+        ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
+        assertCompleteExternalTask(
+            startBusiness,
+            START_BUSINESS_TOPIC,
+            START_BUSINESS_EVENT,
+            START_BUSINESS_ACTIVITY,
+            variables
+        );
+
+        //complete updating case details
+        ExternalTask updateCaseDetails = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            updateCaseDetails,
+            PROCESS_CASE_EVENT,
+            "UPDATE_CASE_DETAILS_AFTER_NOC",
+            "UpdateCaseDetailsAfterNoC"
+        );
+        //complete notify claimant
+        ExternalTask notifyDefendantAfterNoc = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            notifyDefendantAfterNoc,
+            PROCESS_CASE_EVENT,
+            "NOTIFY_DEFENDANT_AFTER_NOC_APPROVAL",
+            "NotifyDefendantLipAfterNocApproval"
+        );
+
+        //complete notify defendant
+        ExternalTask notifyDefendantSolicitorAfterNoc = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            notifyDefendantSolicitorAfterNoc,
+            PROCESS_CASE_EVENT,
+            "NOTIFY_DEFENDANT_SOLICITOR_AFTER_NOC_APPROVAL",
+            "NotifyDefendant1SolicitorRepresented"
+        );
+
+        //complete notify defendant
+        ExternalTask notifyClaimant = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            notifyClaimant,
+            PROCESS_CASE_EVENT,
+            "NOTIFY_CLAIMANT_DEFENDANT_REPRESENTED",
+            "NotifyClaimantLipDefendantRepresented"
+        );
+
+        //Proceed Offline
+        ExternalTask proceedOfflineTask = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            proceedOfflineTask,
+            PROCESS_CASE_EVENT,
+            PROCEEDS_IN_HERITAGE_SYSTEM,
+            PROCEEDS_IN_HERITAGE_SYSTEM_ACTIVITY_ID
+        );
+
+        //Update General Application Status
+        ExternalTask updateApplicationStatus = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            updateApplicationStatus,
+            PROCESS_CASE_EVENT,
+            TRIGGER_APPLICATION_PROCEEDS_IN_HERITAGE,
+            APPLICATION_PROCEEDS_IN_HERITAGE_ACTIVITY_ID
+        );
+
+        //Update Claim Details with General Application Status
+        ExternalTask updateClaimWithApplicationStatus = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            updateClaimWithApplicationStatus,
+            PROCESS_CASE_EVENT,
+            APPLICATION_OFFLINE_UPDATE_CLAIM,
+            APPLICATION_OFFLINE_UPDATE_CLAIM_ACTIVITY_ID
+        );
+
+        ExternalTask claimantGaDashboard = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            claimantGaDashboard,
+            PROCESS_CASE_EVENT,
+            "CREATE_DASHBOARD_NOTIFICATION_APPLICATION_PROCEED_OFFLINE_CLAIMANT",
+            "claimantLipApplicationOfflineDashboardNotification"
+        );
+
+        ExternalTask defendantGaDashboard = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            defendantGaDashboard,
+            PROCESS_CASE_EVENT,
+            "CREATE_DASHBOARD_NOTIFICATION_APPLICATION_PROCEED_OFFLINE_DEFENDANT",
+            "defendantLipApplicationOfflineDashboardNotification"
         );
 
         //complete Dashboard notification

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ApplyNocDecisionDefendantLipTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/ApplyNocDecisionDefendantLipTest.java
@@ -552,7 +552,7 @@ public class ApplyNocDecisionDefendantLipTest extends BpmnBaseTest {
             DEFENDANT_NOC_ONLINE, true,
             JBA_ISSUED_BEFORE_NOC, true,
             CLAIM_STATE_DURING_NOC, false,
-            GENERAL_APPLICATION_ENABLED , true));
+            GENERAL_APPLICATION_ENABLED, true));
 
         //assert process has started
         assertFalse(processInstance.isEnded());


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-17589


### Change description ###
Updated the Defendant liP NOC flow to modify the GA task status when the main case transitions to offline

<img width="1499" height="729" alt="image" src="https://github.com/user-attachments/assets/40a6efde-8a7b-4d2c-b579-6fcb84a61bcb" />



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
