### PR TITLE
CIV-17703 Clean up

### DIFF
--- a/src/main/resources/camunda/raise_query.bpmn
+++ b/src/main/resources/camunda/raise_query.bpmn
@@ -21,7 +21,7 @@
         <camunda:out variables="all" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_07f4qur</bpmn:incoming>
-      <bpmn:outgoing>Flow_0z7ne1a</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1sxw4ow</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:endEvent id="Event_08vk6sg">
       <bpmn:incoming>Flow_1tmwfcu</bpmn:incoming>
@@ -33,61 +33,16 @@
     <bpmn:sequenceFlow id="Flow_07f4qur" sourceRef="Event_RAISE_QUERY" targetRef="Activity_13251ij" />
     <bpmn:sequenceFlow id="Flow_1bdms5y" sourceRef="Activity_06hw69k" targetRef="Event_08cqexo" />
     <bpmn:sequenceFlow id="Flow_1tmwfcu" sourceRef="Event_0qd0ffr" targetRef="Event_08vk6sg" />
-    <bpmn:sequenceFlow id="Flow_0z7ne1a" sourceRef="Activity_13251ij" targetRef="Gateway_0rwxzjt" />
     <bpmn:serviceTask id="QueryRaisedNotify" name="Notify for raised query" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
           <camunda:inputParameter name="caseEvent">NOTIFY_RAISED_QUERY</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_06zppkn</bpmn:incoming>
-      <bpmn:incoming>Flow_1l1axm7</bpmn:incoming>
-      <bpmn:incoming>Flow_18vp23s</bpmn:incoming>
+      <bpmn:incoming>Flow_1sxw4ow</bpmn:incoming>
       <bpmn:outgoing>Flow_1ikpa6q</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_1ikpa6q" sourceRef="QueryRaisedNotify" targetRef="NotifyOtherPartyQueryRaised" />
-    <bpmn:serviceTask id="GenerateQueryDocument" name="Generate Query Document" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">GENERATE_QUERY_DOCUMENT</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_06jx08k</bpmn:incoming>
-      <bpmn:outgoing>Flow_0v7r9wp</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0v7r9wp" sourceRef="GenerateQueryDocument" targetRef="Gateway_06n8c7h" />
-    <bpmn:exclusiveGateway id="Gateway_0rwxzjt">
-      <bpmn:incoming>Flow_0z7ne1a</bpmn:incoming>
-      <bpmn:outgoing>Flow_06jx08k</bpmn:outgoing>
-      <bpmn:outgoing>Flow_06zppkn</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_06jx08k" sourceRef="Gateway_0rwxzjt" targetRef="GenerateQueryDocument">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.PUBLIC_QUERIES_ENABLED &amp;&amp; !flowFlags.PUBLIC_QUERIES_ENABLED}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_06zppkn" name="Lip Claim" sourceRef="Gateway_0rwxzjt" targetRef="QueryRaisedNotify">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.PUBLIC_QUERIES_ENABLED &amp;&amp; flowFlags.PUBLIC_QUERIES_ENABLED}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:exclusiveGateway id="Gateway_06n8c7h">
-      <bpmn:incoming>Flow_0v7r9wp</bpmn:incoming>
-      <bpmn:outgoing>Flow_0rqv8gt</bpmn:outgoing>
-      <bpmn:outgoing>Flow_18vp23s</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_0rqv8gt" sourceRef="Gateway_06n8c7h" targetRef="DeleteQueryDocument">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${removeDocument}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="DeleteQueryDocument" name="Delete Old Query Document" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">DELETE_QUERY_DOCUMENT</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0rqv8gt</bpmn:incoming>
-      <bpmn:outgoing>Flow_1l1axm7</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1l1axm7" sourceRef="DeleteQueryDocument" targetRef="QueryRaisedNotify" />
-    <bpmn:sequenceFlow id="Flow_18vp23s" name="No query document to delete" sourceRef="Gateway_06n8c7h" targetRef="QueryRaisedNotify">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!removeDocument}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
     <bpmn:serviceTask id="NotifyOtherPartyQueryRaised" name="Notify other party query has been raised" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
@@ -108,72 +63,39 @@
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_1gjja0r" sourceRef="NotifyOtherPartyQueryRaised" targetRef="UpdateDashboardNotificationsRaisedQm" />
     <bpmn:sequenceFlow id="Flow_1e66590" sourceRef="UpdateDashboardNotificationsRaisedQm" targetRef="Activity_06hw69k" />
+    <bpmn:sequenceFlow id="Flow_1sxw4ow" sourceRef="Activity_13251ij" targetRef="QueryRaisedNotify" />
   </bpmn:process>
   <bpmn:message id="Message_0rowsbk" name="queryManagementRaiseQuery" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="queryManagementRaiseQuery">
-      <bpmndi:BPMNEdge id="Flow_1e66590_di" bpmnElement="Flow_1e66590">
-        <di:waypoint x="1320" y="210" />
-        <di:waypoint x="1380" y="210" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1gjja0r_di" bpmnElement="Flow_1gjja0r">
-        <di:waypoint x="1160" y="210" />
-        <di:waypoint x="1220" y="210" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_18vp23s_di" bpmnElement="Flow_18vp23s">
-        <di:waypoint x="670" y="235" />
-        <di:waypoint x="670" y="330" />
-        <di:waypoint x="960" y="330" />
-        <di:waypoint x="960" y="250" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="785" y="340" width="61" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1l1axm7_di" bpmnElement="Flow_1l1axm7">
-        <di:waypoint x="850" y="210" />
-        <di:waypoint x="910" y="210" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0rqv8gt_di" bpmnElement="Flow_0rqv8gt">
-        <di:waypoint x="695" y="210" />
-        <di:waypoint x="750" y="210" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_06zppkn_di" bpmnElement="Flow_06zppkn">
-        <di:waypoint x="410" y="185" />
-        <di:waypoint x="410" y="100" />
-        <di:waypoint x="960" y="100" />
-        <di:waypoint x="960" y="170" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="662" y="82" width="46" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_06jx08k_di" bpmnElement="Flow_06jx08k">
-        <di:waypoint x="435" y="210" />
-        <di:waypoint x="480" y="210" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0v7r9wp_di" bpmnElement="Flow_0v7r9wp">
-        <di:waypoint x="580" y="210" />
-        <di:waypoint x="645" y="210" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1ikpa6q_di" bpmnElement="Flow_1ikpa6q">
-        <di:waypoint x="1010" y="210" />
-        <di:waypoint x="1060" y="210" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0z7ne1a_di" bpmnElement="Flow_0z7ne1a">
-        <di:waypoint x="330" y="210" />
-        <di:waypoint x="385" y="210" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1tmwfcu_di" bpmnElement="Flow_1tmwfcu">
         <di:waypoint x="280" y="152" />
         <di:waypoint x="280" y="100" />
         <di:waypoint x="322" y="100" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1bdms5y_di" bpmnElement="Flow_1bdms5y">
-        <di:waypoint x="1480" y="210" />
-        <di:waypoint x="1532" y="210" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_07f4qur_di" bpmnElement="Flow_07f4qur">
         <di:waypoint x="178" y="210" />
         <di:waypoint x="230" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1sxw4ow_di" bpmnElement="Flow_1sxw4ow">
+        <di:waypoint x="330" y="210" />
+        <di:waypoint x="380" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1bdms5y_di" bpmnElement="Flow_1bdms5y">
+        <di:waypoint x="950" y="210" />
+        <di:waypoint x="1002" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1e66590_di" bpmnElement="Flow_1e66590">
+        <di:waypoint x="790" y="210" />
+        <di:waypoint x="850" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ikpa6q_di" bpmnElement="Flow_1ikpa6q">
+        <di:waypoint x="480" y="210" />
+        <di:waypoint x="530" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gjja0r_di" bpmnElement="Flow_1gjja0r">
+        <di:waypoint x="630" y="210" />
+        <di:waypoint x="690" y="210" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1ncp11o_di" bpmnElement="Event_RAISE_QUERY">
         <dc:Bounds x="142" y="192" width="36" height="36" />
@@ -181,38 +103,26 @@
           <dc:Bounds x="149" y="235" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_08cqexo_di" bpmnElement="Event_08cqexo">
-        <dc:Bounds x="1532" y="192" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_06hw69k_di" bpmnElement="Activity_06hw69k">
-        <dc:Bounds x="1380" y="170" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_13251ij_di" bpmnElement="Activity_13251ij">
         <dc:Bounds x="230" y="170" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_08vk6sg_di" bpmnElement="Event_08vk6sg">
         <dc:Bounds x="322" y="82" width="36" height="36" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_08cqexo_di" bpmnElement="Event_08cqexo">
+        <dc:Bounds x="1002" y="192" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_06hw69k_di" bpmnElement="Activity_06hw69k">
+        <dc:Bounds x="850" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1jojnh6_di" bpmnElement="QueryRaisedNotify">
-        <dc:Bounds x="910" y="170" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1r0l8yd_di" bpmnElement="GenerateQueryDocument">
-        <dc:Bounds x="480" y="170" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0rwxzjt_di" bpmnElement="Gateway_0rwxzjt" isMarkerVisible="true">
-        <dc:Bounds x="385" y="185" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_06n8c7h_di" bpmnElement="Gateway_06n8c7h" isMarkerVisible="true">
-        <dc:Bounds x="645" y="185" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_19iqvqr_di" bpmnElement="DeleteQueryDocument">
-        <dc:Bounds x="750" y="170" width="100" height="80" />
+        <dc:Bounds x="380" y="170" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1t8pn26_di" bpmnElement="NotifyOtherPartyQueryRaised">
-        <dc:Bounds x="1060" y="170" width="100" height="80" />
+        <dc:Bounds x="530" y="170" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0vg03ud_di" bpmnElement="UpdateDashboardNotificationsRaisedQm">
-        <dc:Bounds x="1220" y="170" width="100" height="80" />
+        <dc:Bounds x="690" y="170" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0qd0ffr_di" bpmnElement="Event_0qd0ffr">
         <dc:Bounds x="262" y="152" width="36" height="36" />

--- a/src/main/resources/camunda/respond_to_query.bpmn
+++ b/src/main/resources/camunda/respond_to_query.bpmn
@@ -21,9 +21,7 @@
           <camunda:inputParameter name="caseEvent">NOTIFY_RESPONSE_TO_QUERY</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_14qiohc</bpmn:incoming>
-      <bpmn:incoming>Flow_0lu0enj</bpmn:incoming>
-      <bpmn:incoming>Flow_0o8zhry</bpmn:incoming>
+      <bpmn:incoming>Flow_1i59x00</bpmn:incoming>
       <bpmn:outgoing>Flow_0dmbtlk</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:callActivity id="Activity_13251ij" name="Start Business Process" calledElement="StartBusinessProcess">
@@ -32,7 +30,7 @@
         <camunda:out variables="all" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_07f4qur</bpmn:incoming>
-      <bpmn:outgoing>Flow_1328dhu</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1i59x00</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:endEvent id="Event_08vk6sg">
       <bpmn:incoming>Flow_1tmwfcu</bpmn:incoming>
@@ -45,49 +43,6 @@
     <bpmn:sequenceFlow id="Flow_1bdms5y" sourceRef="Activity_06hw69k" targetRef="Event_08cqexo" />
     <bpmn:sequenceFlow id="Flow_0dmbtlk" sourceRef="QueryResponseNotify" targetRef="NotifyOtherPartyQueryHasResponse" />
     <bpmn:sequenceFlow id="Flow_1tmwfcu" sourceRef="Event_0qd0ffr" targetRef="Event_08vk6sg" />
-    <bpmn:sequenceFlow id="Flow_1328dhu" sourceRef="Activity_13251ij" targetRef="Gateway_0c4w1k9" />
-    <bpmn:serviceTask id="GenerateQueryDocument" name="Generate Query Document" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">GENERATE_QUERY_DOCUMENT</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0yz6d8l</bpmn:incoming>
-      <bpmn:outgoing>Flow_1x38j97</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1x38j97" sourceRef="GenerateQueryDocument" targetRef="Gateway_1bzbbwk" />
-    <bpmn:exclusiveGateway id="Gateway_0c4w1k9">
-      <bpmn:incoming>Flow_1328dhu</bpmn:incoming>
-      <bpmn:outgoing>Flow_0yz6d8l</bpmn:outgoing>
-      <bpmn:outgoing>Flow_14qiohc</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_0yz6d8l" sourceRef="Gateway_0c4w1k9" targetRef="GenerateQueryDocument">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${empty flowFlags.PUBLIC_QUERIES_ENABLED || !flowFlags.PUBLIC_QUERIES_ENABLED}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_14qiohc" name="Lip Claim" sourceRef="Gateway_0c4w1k9" targetRef="QueryResponseNotify">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.PUBLIC_QUERIES_ENABLED &amp;&amp; flowFlags.PUBLIC_QUERIES_ENABLED}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="DeleteQueryDocument" name="Delete Old Query Document" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">DELETE_QUERY_DOCUMENT</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0zm0u35</bpmn:incoming>
-      <bpmn:outgoing>Flow_0lu0enj</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:exclusiveGateway id="Gateway_1bzbbwk">
-      <bpmn:incoming>Flow_1x38j97</bpmn:incoming>
-      <bpmn:outgoing>Flow_0zm0u35</bpmn:outgoing>
-      <bpmn:outgoing>Flow_0o8zhry</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_0zm0u35" sourceRef="Gateway_1bzbbwk" targetRef="DeleteQueryDocument">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${removeDocument}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0lu0enj" sourceRef="DeleteQueryDocument" targetRef="QueryResponseNotify" />
-    <bpmn:sequenceFlow id="Flow_0o8zhry" name="No query document to delete" sourceRef="Gateway_1bzbbwk" targetRef="QueryResponseNotify">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!removeDocument}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
     <bpmn:serviceTask id="NotifyOtherPartyQueryHasResponse" name="Notify other party query has response" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
@@ -108,72 +63,39 @@
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_0vzaa5g" sourceRef="NotifyOtherPartyQueryHasResponse" targetRef="UpdateDashboardNotificationsResponseToQuery" />
     <bpmn:sequenceFlow id="Flow_1q6gfdf" sourceRef="UpdateDashboardNotificationsResponseToQuery" targetRef="Activity_06hw69k" />
+    <bpmn:sequenceFlow id="Flow_1i59x00" sourceRef="Activity_13251ij" targetRef="QueryResponseNotify" />
   </bpmn:process>
   <bpmn:message id="Message_0rowsbk" name="queryManagementRespondQuery" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="queryManagementRespondQuery">
-      <bpmndi:BPMNEdge id="Flow_1q6gfdf_di" bpmnElement="Flow_1q6gfdf">
-        <di:waypoint x="1270" y="210" />
-        <di:waypoint x="1320" y="210" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0vzaa5g_di" bpmnElement="Flow_0vzaa5g">
-        <di:waypoint x="1130" y="210" />
-        <di:waypoint x="1170" y="210" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0o8zhry_di" bpmnElement="Flow_0o8zhry">
-        <di:waypoint x="640" y="235" />
-        <di:waypoint x="640" y="320" />
-        <di:waypoint x="910" y="320" />
-        <di:waypoint x="910" y="250" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="745" y="330" width="61" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0lu0enj_di" bpmnElement="Flow_0lu0enj">
-        <di:waypoint x="810" y="210" />
-        <di:waypoint x="860" y="210" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0zm0u35_di" bpmnElement="Flow_0zm0u35">
-        <di:waypoint x="665" y="210" />
-        <di:waypoint x="710" y="210" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_14qiohc_di" bpmnElement="Flow_14qiohc">
-        <di:waypoint x="400" y="185" />
-        <di:waypoint x="400" y="100" />
-        <di:waypoint x="910" y="100" />
-        <di:waypoint x="910" y="170" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="632" y="82" width="46" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0yz6d8l_di" bpmnElement="Flow_0yz6d8l">
-        <di:waypoint x="425" y="210" />
-        <di:waypoint x="470" y="210" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1x38j97_di" bpmnElement="Flow_1x38j97">
-        <di:waypoint x="570" y="210" />
-        <di:waypoint x="615" y="210" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1328dhu_di" bpmnElement="Flow_1328dhu">
-        <di:waypoint x="320" y="210" />
-        <di:waypoint x="375" y="210" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1tmwfcu_di" bpmnElement="Flow_1tmwfcu">
         <di:waypoint x="270" y="152" />
         <di:waypoint x="270" y="100" />
         <di:waypoint x="322" y="100" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0dmbtlk_di" bpmnElement="Flow_0dmbtlk">
-        <di:waypoint x="960" y="210" />
-        <di:waypoint x="1030" y="210" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1bdms5y_di" bpmnElement="Flow_1bdms5y">
-        <di:waypoint x="1420" y="210" />
-        <di:waypoint x="1452" y="210" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_07f4qur_di" bpmnElement="Flow_07f4qur">
         <di:waypoint x="188" y="210" />
         <di:waypoint x="220" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1i59x00_di" bpmnElement="Flow_1i59x00">
+        <di:waypoint x="320" y="210" />
+        <di:waypoint x="370" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1bdms5y_di" bpmnElement="Flow_1bdms5y">
+        <di:waypoint x="910" y="210" />
+        <di:waypoint x="942" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1q6gfdf_di" bpmnElement="Flow_1q6gfdf">
+        <di:waypoint x="760" y="210" />
+        <di:waypoint x="810" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0dmbtlk_di" bpmnElement="Flow_0dmbtlk">
+        <di:waypoint x="470" y="210" />
+        <di:waypoint x="520" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0vzaa5g_di" bpmnElement="Flow_0vzaa5g">
+        <di:waypoint x="620" y="210" />
+        <di:waypoint x="660" y="210" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1ncp11o_di" bpmnElement="Event_QUERY_RESPONSE">
         <dc:Bounds x="152" y="192" width="36" height="36" />
@@ -181,38 +103,26 @@
           <dc:Bounds x="158" y="235" width="25" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_08cqexo_di" bpmnElement="Event_08cqexo">
-        <dc:Bounds x="1452" y="192" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_06hw69k_di" bpmnElement="Activity_06hw69k">
-        <dc:Bounds x="1320" y="170" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1jojnh6_di" bpmnElement="QueryResponseNotify">
-        <dc:Bounds x="860" y="170" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_13251ij_di" bpmnElement="Activity_13251ij">
         <dc:Bounds x="220" y="170" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_08vk6sg_di" bpmnElement="Event_08vk6sg">
         <dc:Bounds x="322" y="82" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1r0l8yd_di" bpmnElement="GenerateQueryDocument">
-        <dc:Bounds x="470" y="170" width="100" height="80" />
+      <bpmndi:BPMNShape id="Event_08cqexo_di" bpmnElement="Event_08cqexo">
+        <dc:Bounds x="942" y="192" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0c4w1k9_di" bpmnElement="Gateway_0c4w1k9" isMarkerVisible="true">
-        <dc:Bounds x="375" y="185" width="50" height="50" />
+      <bpmndi:BPMNShape id="Activity_06hw69k_di" bpmnElement="Activity_06hw69k">
+        <dc:Bounds x="810" y="170" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="DeleteQueryDocument_di" bpmnElement="DeleteQueryDocument">
-        <dc:Bounds x="710" y="170" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1bzbbwk_di" bpmnElement="Gateway_1bzbbwk" isMarkerVisible="true">
-        <dc:Bounds x="615" y="185" width="50" height="50" />
+      <bpmndi:BPMNShape id="Activity_1jojnh6_di" bpmnElement="QueryResponseNotify">
+        <dc:Bounds x="370" y="170" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="NotifyOtherPartyQueryHasResponse_di" bpmnElement="NotifyOtherPartyQueryHasResponse">
-        <dc:Bounds x="1030" y="170" width="100" height="80" />
+        <dc:Bounds x="520" y="170" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1nvtnlv_di" bpmnElement="UpdateDashboardNotificationsResponseToQuery">
-        <dc:Bounds x="1170" y="170" width="100" height="80" />
+        <dc:Bounds x="660" y="170" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0qd0ffr_di" bpmnElement="Event_0qd0ffr">
         <dc:Bounds x="252" y="152" width="36" height="36" />

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/RaiseQueryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/RaiseQueryTest.java
@@ -4,10 +4,6 @@ import org.camunda.bpm.engine.externaltask.ExternalTask;
 import org.camunda.bpm.engine.variable.VariableMap;
 import org.camunda.bpm.engine.variable.Variables;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -16,10 +12,6 @@ class RaiseQueryTest extends BpmnBaseTest {
 
     public static final String MESSAGE_NAME = "queryManagementRaiseQuery";
     public static final String PROCESS_ID = "queryManagementRaiseQuery";
-    private static final String GENERATE_QUERY_DOCUMENT = "GENERATE_QUERY_DOCUMENT";
-    private static final String GENERATE_QUERY_DOCUMENT_ACTIVITY_ID = "GenerateQueryDocument";
-    private static final String DELETE_QUERY_DOCUMENT = "DELETE_QUERY_DOCUMENT";
-    private static final String DELETE_QUERY_DOCUMENT_ACTIVITY_ID = "DeleteQueryDocument";
     private static final String NOTIFY_LR = "NOTIFY_RAISED_QUERY";
     private static final String NOTIFY_OTHER_PARTY = "NOTIFY_OTHER_PARTY_FOR_RAISED_QUERY";
     private static final String NOTIFY_LR_ACTIVITY_ID = "QueryRaisedNotify";
@@ -30,10 +22,8 @@ class RaiseQueryTest extends BpmnBaseTest {
         super("raise_query.bpmn", PROCESS_ID);
     }
 
-    @ParameterizedTest
-    @CsvSource({"true,false", "false,false", "true,true", "false,true"})
-    void shouldSuccessfullyCompleteRaiseQueryProcess_whenCalled(boolean publicQueriesEnabled,
-                                                                boolean removeDocument) {
+    @Test
+    void shouldSuccessfullyCompleteRaiseQueryProcess_whenCalled() {
         //assert process has started
         assertFalse(processInstance.isEnded());
 
@@ -41,11 +31,6 @@ class RaiseQueryTest extends BpmnBaseTest {
         assertThat(getProcessDefinitionByMessage(MESSAGE_NAME).getKey()).isEqualTo(PROCESS_ID);
 
         VariableMap variables = Variables.createVariables();
-        variables.put(
-            FLOW_FLAGS, Map.of(
-                PUBLIC_QUERIES_ENABLED, publicQueriesEnabled
-            ));
-        variables.put("removeDocument", removeDocument);
 
         //complete the start business process
         ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
@@ -56,28 +41,6 @@ class RaiseQueryTest extends BpmnBaseTest {
             START_BUSINESS_ACTIVITY,
             variables
         );
-
-        if (!publicQueriesEnabled) {
-            //generate the query document
-            ExternalTask generateQueryDocumentTask = assertNextExternalTask(PROCESS_CASE_EVENT);
-            assertCompleteExternalTask(
-                generateQueryDocumentTask,
-                PROCESS_CASE_EVENT,
-                GENERATE_QUERY_DOCUMENT,
-                GENERATE_QUERY_DOCUMENT_ACTIVITY_ID
-            );
-
-            if (removeDocument) {
-                //delete the query document
-                ExternalTask deleteQueryDocumentTask = assertNextExternalTask(PROCESS_CASE_EVENT);
-                assertCompleteExternalTask(
-                    deleteQueryDocumentTask,
-                    PROCESS_CASE_EVENT,
-                    DELETE_QUERY_DOCUMENT,
-                    DELETE_QUERY_DOCUMENT_ACTIVITY_ID
-                );
-            }
-        }
 
         //complete the email notification
         ExternalTask notifyLrTask = assertNextExternalTask(PROCESS_CASE_EVENT);

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/RespondToQueryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/RespondToQueryTest.java
@@ -4,10 +4,6 @@ import org.camunda.bpm.engine.externaltask.ExternalTask;
 import org.camunda.bpm.engine.variable.VariableMap;
 import org.camunda.bpm.engine.variable.Variables;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -16,10 +12,6 @@ class RespondToQueryTest extends BpmnBaseTest {
 
     public static final String MESSAGE_NAME = "queryManagementRespondQuery";
     public static final String PROCESS_ID = "queryManagementRespondQuery";
-    private static final String GENERATE_QUERY_DOCUMENT = "GENERATE_QUERY_DOCUMENT";
-    private static final String GENERATE_QUERY_DOCUMENT_ACTIVITY_ID = "GenerateQueryDocument";
-    private static final String DELETE_QUERY_DOCUMENT = "DELETE_QUERY_DOCUMENT";
-    private static final String DELETE_QUERY_DOCUMENT_ACTIVITY_ID = "DeleteQueryDocument";
     private static final String NOTIFY_LR = "NOTIFY_RESPONSE_TO_QUERY";
     private static final String NOTIFY_OTHER_PARTY = "NOTIFY_OTHER_PARTY_QUERY_HAS_RESPONSE";
     private static final String NOTIFY_LR_ACTIVITY_ID = "QueryResponseNotify";
@@ -31,10 +23,8 @@ class RespondToQueryTest extends BpmnBaseTest {
         super("respond_to_query.bpmn", PROCESS_ID);
     }
 
-    @ParameterizedTest
-    @CsvSource({"false,false", "true,false", "false,true", "true,true"})
-    void shouldSuccessfullyCompleteRespondToQueryProcess_whenCalled(boolean publicQueriesEnabled,
-                                                                    boolean removeDocument) {
+    @Test
+    void shouldSuccessfullyCompleteRespondToQueryProcess_whenCalled() {
         //assert process has started
         assertFalse(processInstance.isEnded());
 
@@ -42,10 +32,6 @@ class RespondToQueryTest extends BpmnBaseTest {
         assertThat(getProcessDefinitionByMessage(MESSAGE_NAME).getKey()).isEqualTo(PROCESS_ID);
 
         VariableMap variables = Variables.createVariables();
-        variables.put(FLOW_FLAGS, Map.of(
-            PUBLIC_QUERIES_ENABLED, publicQueriesEnabled
-        ));
-        variables.put("removeDocument", removeDocument);
 
         //complete the start business process
         ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
@@ -56,28 +42,6 @@ class RespondToQueryTest extends BpmnBaseTest {
             START_BUSINESS_ACTIVITY,
             variables
         );
-
-        if (!publicQueriesEnabled) {
-            //generate the query document
-            ExternalTask generateQueryDocumentTask = assertNextExternalTask(PROCESS_CASE_EVENT);
-            assertCompleteExternalTask(
-                generateQueryDocumentTask,
-                PROCESS_CASE_EVENT,
-                GENERATE_QUERY_DOCUMENT,
-                GENERATE_QUERY_DOCUMENT_ACTIVITY_ID
-            );
-
-            if (removeDocument) {
-                //delete the query document
-                ExternalTask deleteQueryDocumentTask = assertNextExternalTask(PROCESS_CASE_EVENT);
-                assertCompleteExternalTask(
-                    deleteQueryDocumentTask,
-                    PROCESS_CASE_EVENT,
-                    DELETE_QUERY_DOCUMENT,
-                    DELETE_QUERY_DOCUMENT_ACTIVITY_ID
-                );
-            }
-        }
 
         //complete the email notification
         ExternalTask forRobotics = assertNextExternalTask(PROCESS_CASE_EVENT);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-17703

### Change description ###
Removed generate query document and delete query document steps from the raise and respond query Camunda flows.

**Raise query**
<img width="1015" height="407" alt="Screenshot 2025-09-16 at 14 17 03" src="https://github.com/user-attachments/assets/c1524788-b566-44fa-ae45-004d8162456b" />

**Respond to Query**
<img width="938" height="422" alt="Screenshot 2025-09-16 at 14 18 11" src="https://github.com/user-attachments/assets/5fc5c0d2-f61a-400b-b98e-5e035ef42ee5" />


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
