### PR TITLE
DTSCCI-4124 Refactor judgment_by_admission_non_divergent_spec.bpmn to…

### DIFF
--- a/src/main/resources/camunda/judgment_by_admission_non_divergent_spec.bpmn
+++ b/src/main/resources/camunda/judgment_by_admission_non_divergent_spec.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1iivus5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.12.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1iivus5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.40.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
   <bpmn:process id="JUDGEMENT_BY_ADMISSION_NON_DIVERGENT_SPEC_ID" name="Request judgement admission spec" isExecutable="true" camunda:historyTimeToLive="P90D">
     <bpmn:startEvent id="Event_0y09tpb" name="Start">
       <bpmn:outgoing>Flow_07qelqa</bpmn:outgoing>
@@ -48,7 +48,7 @@
       <bpmn:incoming>Flow_0gr1zzh</bpmn:incoming>
       <bpmn:outgoing>Flow_0hypzcm</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1glyjdm" sourceRef="Activity_1d3ska5" targetRef="NotifyClaimantJudgmentByAdmission" />
+    <bpmn:sequenceFlow id="Flow_1glyjdm" sourceRef="Activity_1d3ska5" targetRef="JudgmentByAdmissionNotifier" />
     <bpmn:serviceTask id="PostPINInLetterLIPDefendant" name="Post PIN in Letter Defendant LiP" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
@@ -81,26 +81,16 @@
       <bpmn:outgoing>Flow_075i2tt</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_075i2tt" sourceRef="GenerateJudgmentByAdmissionDocDefendant" targetRef="Gateway_1p7qft3" />
-    <bpmn:serviceTask id="NotifyClaimantJudgmentByAdmission" name="Notify  judgment by admission claimant" camunda:type="external" camunda:topic="processCaseEvent">
+    <bpmn:serviceTask id="JudgmentByAdmissionNotifier" name="Notify parties judgment by admission" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_CLAIMANT_JUDGMENT_BY_ADMISSION</camunda:inputParameter>
+          <camunda:inputParameter name="caseEvent">NOTIFY_EVENT</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1glyjdm</bpmn:incoming>
-      <bpmn:outgoing>Flow_0wfvh31</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0wfvh31" sourceRef="NotifyClaimantJudgmentByAdmission" targetRef="NotifyDefendantJudgmentByAdmission" />
-    <bpmn:serviceTask id="NotifyDefendantJudgmentByAdmission" name="Notify judgment by admission Defendant" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_DEFENDANT_JUDGMENT_BY_ADMISSION</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0wfvh31</bpmn:incoming>
       <bpmn:outgoing>Flow_1o1rhx8</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1o1rhx8" sourceRef="NotifyDefendantJudgmentByAdmission" targetRef="GenerateJudgmentByAdmissionDocClaimant" />
+    <bpmn:sequenceFlow id="Flow_1o1rhx8" sourceRef="JudgmentByAdmissionNotifier" targetRef="GenerateJudgmentByAdmissionDocClaimant" />
     <bpmn:sequenceFlow id="Flow_1qe9fnl" sourceRef="PostPINInLetterLIPDefendant" targetRef="GenerateDashboardNotificationJudgementByAdmissionClaimant" />
     <bpmn:serviceTask id="GenerateDashboardNotificationJudgementByAdmissionClaimant" name="Generate Dashboard Notification Claimant 1" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
@@ -174,109 +164,6 @@
   <bpmn:message id="Message_1osgsc5" name="JUDGEMENT_BY_ADMISSION_NON_DIVERGENT_SPEC" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="JUDGEMENT_BY_ADMISSION_NON_DIVERGENT_SPEC_ID">
-      <bpmndi:BPMNEdge id="Flow_0p9b7pn_di" bpmnElement="Flow_0p9b7pn">
-        <di:waypoint x="1070" y="255" />
-        <di:waypoint x="1070" y="370" />
-        <di:waypoint x="1390" y="370" />
-        <di:waypoint x="1390" y="255" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1077" y="296" width="68" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_04huk4w_di" bpmnElement="Flow_04huk4w">
-        <di:waypoint x="1095" y="230" />
-        <di:waypoint x="1180" y="230" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1085" y="198" width="68" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_172e2im_di" bpmnElement="Flow_IS_JO_LIVE_FEED_ACTIVE_ENABLED">
-        <di:waypoint x="1390" y="205" />
-        <di:waypoint x="1390" y="110" />
-        <di:waypoint x="1770" y="110" />
-        <di:waypoint x="1770" y="205" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1413" y="76" width="73" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1e8qg53_di" bpmnElement="Flow_1e8qg53">
-        <di:waypoint x="1630" y="230" />
-        <di:waypoint x="1745" y="230" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1ymdzjr_di" bpmnElement="Flow_IS_JO_LIVE_FEED_ACTIVE_DISABLED">
-        <di:waypoint x="1415" y="230" />
-        <di:waypoint x="1530" y="230" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1415" y="236" width="71" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0nk6y2d_di" bpmnElement="Flow_0nk6y2d">
-        <di:waypoint x="1280" y="230" />
-        <di:waypoint x="1365" y="230" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0hypzcm_di" bpmnElement="Flow_0hypzcm">
-        <di:waypoint x="2120" y="320" />
-        <di:waypoint x="2120" y="270" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1lamj8i_di" bpmnElement="Flow_1lamj8i">
-        <di:waypoint x="1795" y="230" />
-        <di:waypoint x="2070" y="230" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1807" y="198" width="90" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0gr1zzh_di" bpmnElement="Flow_0gr1zzh">
-        <di:waypoint x="1990" y="360" />
-        <di:waypoint x="2070" y="360" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1qe9fnl_di" bpmnElement="Flow_1qe9fnl">
-        <di:waypoint x="1820" y="360" />
-        <di:waypoint x="1890" y="360" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1o1rhx8_di" bpmnElement="Flow_1o1rhx8">
-        <di:waypoint x="660" y="230" />
-        <di:waypoint x="710" y="230" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0wfvh31_di" bpmnElement="Flow_0wfvh31">
-        <di:waypoint x="500" y="230" />
-        <di:waypoint x="560" y="230" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_075i2tt_di" bpmnElement="Flow_075i2tt">
-        <di:waypoint x="960" y="230" />
-        <di:waypoint x="1045" y="230" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_085619d_di" bpmnElement="Flow_085619d">
-        <di:waypoint x="810" y="230" />
-        <di:waypoint x="860" y="230" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1a58dzr_di" bpmnElement="Flow_1a58dzr">
-        <di:waypoint x="1770" y="255" />
-        <di:waypoint x="1770" y="320" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1694" y="293" width="71" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1glyjdm_di" bpmnElement="Flow_1glyjdm">
-        <di:waypoint x="350" y="230" />
-        <di:waypoint x="400" y="230" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1kj896s_di" bpmnElement="Flow_1kj896s">
-        <di:waypoint x="2320" y="230" />
-        <di:waypoint x="2362" y="230" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0uk4gkm_di" bpmnElement="Flow_0uk4gkm">
-        <di:waypoint x="300" y="172" />
-        <di:waypoint x="300" y="130" />
-        <di:waypoint x="432" y="130" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_07qelqa_di" bpmnElement="Flow_07qelqa">
-        <di:waypoint x="188" y="230" />
-        <di:waypoint x="250" y="230" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0j9b0wd_di" bpmnElement="Flow_0j9b0wd">
-        <di:waypoint x="2170" y="230" />
-        <di:waypoint x="2220" y="230" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_0y09tpb_di" bpmnElement="Event_0y09tpb">
         <dc:Bounds x="152" y="212" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -288,6 +175,12 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1o998qy_di" bpmnElement="Event_1o998qy">
         <dc:Bounds x="432" y="112" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1g0kcde_di" bpmnElement="Event_1g0kcde">
+        <dc:Bounds x="2362" y="212" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0g68wbz_di" bpmnElement="Activity_0g68wbz">
+        <dc:Bounds x="2220" y="190" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0hdpgwf" bpmnElement="Gateway_00bae9b" isMarkerVisible="true">
         <dc:Bounds x="1745" y="205" width="50" height="50" />
@@ -303,20 +196,8 @@
         <dc:Bounds x="1720" y="320" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1orii9b" bpmnElement="GenerateJudgmentByAdmissionDocClaimant">
-        <dc:Bounds x="710" y="190" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0qir5u2" bpmnElement="GenerateJudgmentByAdmissionDocDefendant">
-        <dc:Bounds x="860" y="190" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1yc07hy" bpmnElement="NotifyClaimantJudgmentByAdmission">
-        <dc:Bounds x="400" y="190" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1vsu8bw" bpmnElement="NotifyDefendantJudgmentByAdmission">
-        <dc:Bounds x="560" y="190" width="100" height="80" />
+      <bpmndi:BPMNShape id="BPMNShape_1pmarl0" bpmnElement="GenerateDashboardNotificationJudgementByAdmissionClaimant">
+        <dc:Bounds x="1890" y="320" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_072bzew" bpmnElement="NotifyRoboticsOnContinuousFeed">
@@ -338,14 +219,16 @@
       <bpmndi:BPMNShape id="PostClaimantLIPJBALetter_di" bpmnElement="PostClaimantLIPJBALetter">
         <dc:Bounds x="2070" y="190" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0g68wbz_di" bpmnElement="Activity_0g68wbz">
-        <dc:Bounds x="2220" y="190" width="100" height="80" />
+      <bpmndi:BPMNShape id="BPMNShape_1vsu8bw" bpmnElement="JudgmentByAdmissionNotifier">
+        <dc:Bounds x="460" y="190" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1g0kcde_di" bpmnElement="Event_1g0kcde">
-        <dc:Bounds x="2362" y="212" width="36" height="36" />
+      <bpmndi:BPMNShape id="BPMNShape_1orii9b" bpmnElement="GenerateJudgmentByAdmissionDocClaimant">
+        <dc:Bounds x="650" y="190" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1pmarl0" bpmnElement="GenerateDashboardNotificationJudgementByAdmissionClaimant">
-        <dc:Bounds x="1890" y="320" width="100" height="80" />
+      <bpmndi:BPMNShape id="BPMNShape_0qir5u2" bpmnElement="GenerateJudgmentByAdmissionDocDefendant">
+        <dc:Bounds x="850" y="190" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0371z1y_di" bpmnElement="Event_0371z1y">
@@ -354,6 +237,105 @@
           <dc:Bounds x="338" y="153" width="27" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_07qelqa_di" bpmnElement="Flow_07qelqa">
+        <di:waypoint x="188" y="230" />
+        <di:waypoint x="250" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uk4gkm_di" bpmnElement="Flow_0uk4gkm">
+        <di:waypoint x="300" y="172" />
+        <di:waypoint x="300" y="130" />
+        <di:waypoint x="432" y="130" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1kj896s_di" bpmnElement="Flow_1kj896s">
+        <di:waypoint x="2320" y="230" />
+        <di:waypoint x="2362" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1glyjdm_di" bpmnElement="Flow_1glyjdm">
+        <di:waypoint x="350" y="230" />
+        <di:waypoint x="460" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1a58dzr_di" bpmnElement="Flow_1a58dzr">
+        <di:waypoint x="1770" y="255" />
+        <di:waypoint x="1770" y="320" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1694" y="293" width="71" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_085619d_di" bpmnElement="Flow_085619d">
+        <di:waypoint x="750" y="230" />
+        <di:waypoint x="850" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_075i2tt_di" bpmnElement="Flow_075i2tt">
+        <di:waypoint x="950" y="230" />
+        <di:waypoint x="1045" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1o1rhx8_di" bpmnElement="Flow_1o1rhx8">
+        <di:waypoint x="560" y="230" />
+        <di:waypoint x="650" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1qe9fnl_di" bpmnElement="Flow_1qe9fnl">
+        <di:waypoint x="1820" y="360" />
+        <di:waypoint x="1890" y="360" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0gr1zzh_di" bpmnElement="Flow_0gr1zzh">
+        <di:waypoint x="1990" y="360" />
+        <di:waypoint x="2070" y="360" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1lamj8i_di" bpmnElement="Flow_1lamj8i">
+        <di:waypoint x="1795" y="230" />
+        <di:waypoint x="2070" y="230" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1807" y="198" width="90" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0hypzcm_di" bpmnElement="Flow_0hypzcm">
+        <di:waypoint x="2120" y="320" />
+        <di:waypoint x="2120" y="270" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0nk6y2d_di" bpmnElement="Flow_0nk6y2d">
+        <di:waypoint x="1280" y="230" />
+        <di:waypoint x="1365" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ymdzjr_di" bpmnElement="Flow_IS_JO_LIVE_FEED_ACTIVE_DISABLED">
+        <di:waypoint x="1415" y="230" />
+        <di:waypoint x="1530" y="230" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1415" y="236" width="71" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1e8qg53_di" bpmnElement="Flow_1e8qg53">
+        <di:waypoint x="1630" y="230" />
+        <di:waypoint x="1745" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_172e2im_di" bpmnElement="Flow_IS_JO_LIVE_FEED_ACTIVE_ENABLED">
+        <di:waypoint x="1390" y="205" />
+        <di:waypoint x="1390" y="110" />
+        <di:waypoint x="1770" y="110" />
+        <di:waypoint x="1770" y="205" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1413" y="76" width="73" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04huk4w_di" bpmnElement="Flow_04huk4w">
+        <di:waypoint x="1095" y="230" />
+        <di:waypoint x="1180" y="230" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1085" y="198" width="68" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0p9b7pn_di" bpmnElement="Flow_0p9b7pn">
+        <di:waypoint x="1070" y="255" />
+        <di:waypoint x="1070" y="370" />
+        <di:waypoint x="1390" y="370" />
+        <di:waypoint x="1390" y="255" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1077" y="296" width="68" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0j9b0wd_di" bpmnElement="Flow_0j9b0wd">
+        <di:waypoint x="2170" y="230" />
+        <di:waypoint x="2220" y="230" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/RequestNonDivergentJudgmentByAdmissionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/RequestNonDivergentJudgmentByAdmissionTest.java
@@ -65,16 +65,8 @@ class RequestNonDivergentJudgmentByAdmissionTest extends BpmnBaseTest {
         assertCompleteExternalTask(
             claimantNotification,
             PROCESS_CASE_EVENT,
-            "NOTIFY_CLAIMANT_JUDGMENT_BY_ADMISSION",
-            "NotifyClaimantJudgmentByAdmission"
-        );
-
-        ExternalTask defendantNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            defendantNotification,
-            PROCESS_CASE_EVENT,
-            "NOTIFY_DEFENDANT_JUDGMENT_BY_ADMISSION",
-            "NotifyDefendantJudgmentByAdmission"
+            "NOTIFY_EVENT",
+            "JudgmentByAdmissionNotifier"
         );
 
         ExternalTask generateDocClaimant = assertNextExternalTask(PROCESS_CASE_EVENT);


### PR DESCRIPTION
… use generic notify event

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSCCI-4124


### Change description ###
DTSCCI-4124 - Refactor judgment_by_admission_non_divergent_spec.bpmn to use generic notify event
Before
<img width="2283" height="381" alt="DTSCCI-4124-Before" src="https://github.com/user-attachments/assets/294c9acb-f979-4bdd-afb1-44513e3ae79e" />

After
<img width="2295" height="370" alt="DTSCCI-4124-After" src="https://github.com/user-attachments/assets/6f641572-6e5c-405d-896e-366cd6bda048" />



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
