### PR TITLE
DTSCCI-4124 Refactor judgment_by_admission_non_divergent_spec.bpmn to…

### DIFF
--- a/charts/civil-camunda/values.preview.template.yaml
+++ b/charts/civil-camunda/values.preview.template.yaml
@@ -4,7 +4,7 @@ spring:
 
 java:
   applicationPort: 4000
-  image: hmctsprod.azurecr.io/civil/service:pr-7628
+  image: hmctsprod.azurecr.io/civil/service:${CIVIL_SERVICE_IMAGE}
   imagePullPolicy: Always
   ingressHost: ${SERVICE_NAME}.preview.platform.hmcts.net
   devcpuRequests: 500m

--- a/charts/civil-camunda/values.preview.template.yaml
+++ b/charts/civil-camunda/values.preview.template.yaml
@@ -4,7 +4,7 @@ spring:
 
 java:
   applicationPort: 4000
-  image: hmctsprod.azurecr.io/civil/service:${CIVIL_SERVICE_IMAGE}
+  image: hmctsprod.azurecr.io/civil/service:pr-7628
   imagePullPolicy: Always
   ingressHost: ${SERVICE_NAME}.preview.platform.hmcts.net
   devcpuRequests: 500m

--- a/src/main/resources/camunda/judgment_by_admission_non_divergent_spec.bpmn
+++ b/src/main/resources/camunda/judgment_by_admission_non_divergent_spec.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1iivus5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.28.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1iivus5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.40.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
   <bpmn:process id="JUDGEMENT_BY_ADMISSION_NON_DIVERGENT_SPEC_ID" name="Request judgement admission spec" isExecutable="true" camunda:historyTimeToLive="P90D">
     <bpmn:startEvent id="Event_0y09tpb" name="Start">
       <bpmn:outgoing>Flow_07qelqa</bpmn:outgoing>
@@ -39,7 +39,7 @@
       <bpmn:outgoing>Flow_1a58dzr</bpmn:outgoing>
       <bpmn:outgoing>Flow_1lamj8i</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_1glyjdm" sourceRef="Activity_1d3ska5" targetRef="NotifyClaimantJudgmentByAdmission" />
+    <bpmn:sequenceFlow id="Flow_1glyjdm" sourceRef="Activity_1d3ska5" targetRef="JudgmentByAdmissionNotifier" />
     <bpmn:serviceTask id="PostPINInLetterLIPDefendant" name="Post PIN in Letter Defendant LiP" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
@@ -58,7 +58,7 @@
           <camunda:inputParameter name="caseEvent">GEN_JUDGMENT_BY_ADMISSION_DOC_CLAIMANT</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1o1rhx8</bpmn:incoming>
+      <bpmn:incoming>Flow_0wfvh31</bpmn:incoming>
       <bpmn:outgoing>Flow_085619d</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_085619d" sourceRef="GenerateJudgmentByAdmissionDocClaimant" targetRef="GenerateJudgmentByAdmissionDocDefendant" />
@@ -72,26 +72,16 @@
       <bpmn:outgoing>Flow_075i2tt</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_075i2tt" sourceRef="GenerateJudgmentByAdmissionDocDefendant" targetRef="Gateway_1p7qft3" />
-    <bpmn:serviceTask id="NotifyClaimantJudgmentByAdmission" name="Notify  judgment by admission claimant" camunda:type="external" camunda:topic="processCaseEvent">
+    <bpmn:serviceTask id="JudgmentByAdmissionNotifier" name="Notify  parties judgment by admission" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_CLAIMANT_JUDGMENT_BY_ADMISSION</camunda:inputParameter>
+          <camunda:inputParameter name="caseEvent">NOTIFY_EVENT</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1glyjdm</bpmn:incoming>
       <bpmn:outgoing>Flow_0wfvh31</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0wfvh31" sourceRef="NotifyClaimantJudgmentByAdmission" targetRef="NotifyDefendantJudgmentByAdmission" />
-    <bpmn:serviceTask id="NotifyDefendantJudgmentByAdmission" name="Notify judgment by admission Defendant" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_DEFENDANT_JUDGMENT_BY_ADMISSION</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0wfvh31</bpmn:incoming>
-      <bpmn:outgoing>Flow_1o1rhx8</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1o1rhx8" sourceRef="NotifyDefendantJudgmentByAdmission" targetRef="GenerateJudgmentByAdmissionDocClaimant" />
+    <bpmn:sequenceFlow id="Flow_0wfvh31" sourceRef="JudgmentByAdmissionNotifier" targetRef="GenerateJudgmentByAdmissionDocClaimant" />
     <bpmn:sequenceFlow id="Flow_1qe9fnl" sourceRef="PostPINInLetterLIPDefendant" targetRef="GenerateDashboardNotificationsJudgementByAdmissionNonDivergentSpec" />
     <bpmn:serviceTask id="GenerateDashboardNotificationsJudgementByAdmissionNonDivergentSpec" name="Dashboard Notifications" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
@@ -192,20 +182,8 @@
         <dc:Bounds x="1720" y="320" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1orii9b" bpmnElement="GenerateJudgmentByAdmissionDocClaimant">
-        <dc:Bounds x="710" y="190" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0qir5u2" bpmnElement="GenerateJudgmentByAdmissionDocDefendant">
-        <dc:Bounds x="860" y="190" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1yc07hy" bpmnElement="NotifyClaimantJudgmentByAdmission">
-        <dc:Bounds x="400" y="190" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1vsu8bw" bpmnElement="NotifyDefendantJudgmentByAdmission">
-        <dc:Bounds x="560" y="190" width="100" height="80" />
+      <bpmndi:BPMNShape id="BPMNShape_1pmarl0" bpmnElement="GenerateDashboardNotificationsJudgementByAdmissionNonDivergentSpec">
+        <dc:Bounds x="1940" y="320" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_072bzew" bpmnElement="NotifyRoboticsOnContinuousFeed">
@@ -227,8 +205,16 @@
       <bpmndi:BPMNShape id="PostClaimantLIPJBALetter_di" bpmnElement="PostClaimantLIPJBALetter">
         <dc:Bounds x="2070" y="190" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1pmarl0" bpmnElement="GenerateDashboardNotificationsJudgementByAdmissionNonDivergentSpec">
-        <dc:Bounds x="1940" y="320" width="100" height="80" />
+      <bpmndi:BPMNShape id="BPMNShape_1orii9b" bpmnElement="GenerateJudgmentByAdmissionDocClaimant">
+        <dc:Bounds x="640" y="190" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0qir5u2" bpmnElement="GenerateJudgmentByAdmissionDocDefendant">
+        <dc:Bounds x="840" y="190" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1yc07hy" bpmnElement="JudgmentByAdmissionNotifier">
+        <dc:Bounds x="430" y="190" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0371z1y_di" bpmnElement="Event_0371z1y">
@@ -252,7 +238,7 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1glyjdm_di" bpmnElement="Flow_1glyjdm">
         <di:waypoint x="350" y="230" />
-        <di:waypoint x="400" y="230" />
+        <di:waypoint x="430" y="230" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1a58dzr_di" bpmnElement="Flow_1a58dzr">
         <di:waypoint x="1770" y="255" />
@@ -262,20 +248,16 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_085619d_di" bpmnElement="Flow_085619d">
-        <di:waypoint x="810" y="230" />
-        <di:waypoint x="860" y="230" />
+        <di:waypoint x="740" y="230" />
+        <di:waypoint x="840" y="230" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_075i2tt_di" bpmnElement="Flow_075i2tt">
-        <di:waypoint x="960" y="230" />
+        <di:waypoint x="940" y="230" />
         <di:waypoint x="1045" y="230" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0wfvh31_di" bpmnElement="Flow_0wfvh31">
-        <di:waypoint x="500" y="230" />
-        <di:waypoint x="560" y="230" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1o1rhx8_di" bpmnElement="Flow_1o1rhx8">
-        <di:waypoint x="660" y="230" />
-        <di:waypoint x="710" y="230" />
+        <di:waypoint x="530" y="230" />
+        <di:waypoint x="640" y="230" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1qe9fnl_di" bpmnElement="Flow_1qe9fnl">
         <di:waypoint x="1820" y="360" />

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/RequestNonDivergentJudgmentByAdmissionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/RequestNonDivergentJudgmentByAdmissionTest.java
@@ -65,16 +65,8 @@ class RequestNonDivergentJudgmentByAdmissionTest extends BpmnBaseTest {
         assertCompleteExternalTask(
             claimantNotification,
             PROCESS_CASE_EVENT,
-            "NOTIFY_CLAIMANT_JUDGMENT_BY_ADMISSION",
-            "NotifyClaimantJudgmentByAdmission"
-        );
-
-        ExternalTask defendantNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            defendantNotification,
-            PROCESS_CASE_EVENT,
-            "NOTIFY_DEFENDANT_JUDGMENT_BY_ADMISSION",
-            "NotifyDefendantJudgmentByAdmission"
+            "NOTIFY_EVENT",
+            "JudgmentByAdmissionNotifier"
         );
 
         ExternalTask generateDocClaimant = assertNextExternalTask(PROCESS_CASE_EVENT);


### PR DESCRIPTION
… use generic notify event

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSCCI-4124


### Change description ###
DTSCCI-4124 - Refactor judgment_by_admission_non_divergent_spec.bpmn to use generic notify event

Before
<img width="2283" height="381" alt="DTSCCI-4124-Before" src="https://github.com/user-attachments/assets/3ebb8ee1-8082-4f92-905d-21a4dc7ad0d1" />

After 
<img width="2295" height="370" alt="DTSCCI-4124-After" src="https://github.com/user-attachments/assets/69775bb3-677c-4aba-9494-6a88cd1573cd" />



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
