### PR TITLE
Welsh Dashboard notification is NOT displayed for Claimant

### DIFF
--- a/src/main/resources/camunda/defendant_response_cui.bpmn
+++ b/src/main/resources/camunda/defendant_response_cui.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_18h9iji" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.35.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_18h9iji" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.39.0">
   <bpmn:process id="DEFENDANT_RESPONSE_PROCESS_ID_CUI" name="Defendant response process cui" isExecutable="true" camunda:historyTimeToLive="P90D">
     <bpmn:startEvent id="StartEvent_1" name="start">
       <bpmn:outgoing>Flow_01gz2ld</bpmn:outgoing>
@@ -60,7 +60,7 @@
       <bpmn:incoming>Flow_0u423n9</bpmn:incoming>
       <bpmn:outgoing>Flow_1hktj3p</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:serviceTask id="GenerateDashboardNotificationsDefendantResponse" name="Generate Dashboard Notifications" camunda:type="external" camunda:topic="processCaseEvent">
+    <bpmn:serviceTask id="GenerateDashboardNotificationsDefendantResponseCUI" name="Generate Dashboard Notifications" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
           <camunda:inputParameter name="caseEvent">DASHBOARD_NOTIFICATION_EVENT</camunda:inputParameter>
@@ -70,7 +70,7 @@
       <bpmn:incoming>Flow_036qzxt</bpmn:incoming>
       <bpmn:outgoing>Flow_0u423n9</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0u423n9" sourceRef="GenerateDashboardNotificationsDefendantResponse" targetRef="GenerateSealedLipDQPdf" />
+    <bpmn:sequenceFlow id="Flow_0u423n9" sourceRef="GenerateDashboardNotificationsDefendantResponseCUI" targetRef="GenerateSealedLipDQPdf" />
     <bpmn:sequenceFlow id="Flow_08c114p" sourceRef="GenerateSealedLipResponsePdf" targetRef="Activity_1m5szz9" />
     <bpmn:sequenceFlow id="Flow_1hktj3p" sourceRef="GenerateSealedLipDQPdf" targetRef="GenerateSealedLipResponsePdf" />
     <bpmn:exclusiveGateway id="Gateway_1g5wy1u" name="citizen language?">
@@ -78,11 +78,11 @@
       <bpmn:outgoing>Flow_17mobwo</bpmn:outgoing>
       <bpmn:outgoing>Flow_03k1grm</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_17mobwo" name="welsh" sourceRef="Gateway_1g5wy1u" targetRef="GenerateDashboardNotificationsDefendantResponse">
+    <bpmn:sequenceFlow id="Flow_17mobwo" name="welsh" sourceRef="Gateway_1g5wy1u" targetRef="GenerateDashboardNotificationsDefendantResponseCUI">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${!empty flowFlags.RESPONDENT_RESPONSE_LANGUAGE_IS_BILINGUAL &amp;&amp; flowFlags.RESPONDENT_RESPONSE_LANGUAGE_IS_BILINGUAL || ((!empty flowFlags.WELSH_ENABLED &amp;&amp; flowFlags.WELSH_ENABLED) &amp;&amp; (!empty flowFlags.CLAIM_ISSUE_BILINGUAL &amp;&amp; flowFlags.CLAIM_ISSUE_BILINGUAL))}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_03k1grm" name="English" sourceRef="Gateway_1g5wy1u" targetRef="DefendantResponseCUINotify" />
-    <bpmn:sequenceFlow id="Flow_036qzxt" sourceRef="DefendantResponseCUINotify" targetRef="GenerateDashboardNotificationsDefendantResponse" />
+    <bpmn:sequenceFlow id="Flow_036qzxt" sourceRef="DefendantResponseCUINotify" targetRef="GenerateDashboardNotificationsDefendantResponseCUI" />
     <bpmn:sequenceFlow id="Flow_1titg0d" sourceRef="Activity_1nraabm" targetRef="Gateway_1g5wy1u" />
   </bpmn:process>
   <bpmn:message id="Message_1xf7rku" name="DEFENDANT_RESPONSE_CUI" />
@@ -111,23 +111,23 @@
         <dc:Bounds x="740" y="176" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1g5wy1u_di" bpmnElement="Gateway_1g5wy1u" isMarkerVisible="true">
-        <dc:Bounds x="415" y="191" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="398" y="161" width="86" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_1k0aevm" bpmnElement="GenerateDashboardNotificationsDefendantResponse">
-        <dc:Bounds x="1050" y="176" width="100" height="80" />
+      <bpmndi:BPMNShape id="BPMNShape_0mbmpfa" bpmnElement="GenerateSealedLipResponsePdf">
+        <dc:Bounds x="1500" y="176" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1pxynue" bpmnElement="GenerateSealedLipDQPdf">
         <dc:Bounds x="1280" y="176" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0mbmpfa" bpmnElement="GenerateSealedLipResponsePdf">
-        <dc:Bounds x="1500" y="176" width="100" height="80" />
+      <bpmndi:BPMNShape id="BPMNShape_1k0aevm" bpmnElement="GenerateDashboardNotificationsDefendantResponseCUI">
+        <dc:Bounds x="1050" y="176" width="100" height="80" />
         <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1g5wy1u_di" bpmnElement="Gateway_1g5wy1u" isMarkerVisible="true">
+        <dc:Bounds x="415" y="191" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="398" y="161" width="86" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1wie3up_di" bpmnElement="Event_1wie3up">
         <dc:Bounds x="272" y="155" width="36" height="36" />

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/DefendantResponseCuiTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/DefendantResponseCuiTest.java
@@ -25,7 +25,7 @@ public class DefendantResponseCuiTest extends BpmnBaseTest {
     private static final String GENERATE_LIP_DQ_PDF_ACTIVITY = "GenerateSealedLipDQPdf";
     private static final String GENERATE_LIP_RESPONSE_PDF_ACTIVITY = "GenerateSealedLipResponsePdf";
     private static final String GENERATE_DASHBOARD_ACTIVITY
-        = "GenerateDashboardNotificationsDefendantResponse";
+        = "GenerateDashboardNotificationsDefendantResponseCUI";
 
     public DefendantResponseCuiTest() {
         super(


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSCCI-4218


### Change description ###
defendant_response_cui.bpmn now uses GenerateDashboardNotificationsDefendantResponseCUI activity id for dashboard notifications.  This is the only bpmn that needs to process the biligual logic in civil-service.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
