### PR TITLE
Fix translated documents process notification

### DIFF
--- a/src/main/resources/camunda/upload_translated_defendant_sealed_form.bpmn
+++ b/src/main/resources/camunda/upload_translated_defendant_sealed_form.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0rn46su" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.35.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0rn46su" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.39.0">
   <bpmn:process id="UPLOAD_TRANSLATED_DEFENDANT_SEALED_FORM" name="Upload translated defendant sealed claim form" isExecutable="true" camunda:historyTimeToLive="P90D">
     <bpmn:callActivity id="UPLOADTRANSLATEDDISCONTINUANCEDOC" name="Start Business Process" calledElement="StartBusinessProcess">
       <bpmn:extensionElements>
@@ -69,7 +69,7 @@
       <bpmn:incoming>Flow_1axf4zx</bpmn:incoming>
       <bpmn:outgoing>Flow_0k04xdu</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:serviceTask id="DefendantResponseUnspecFullDefenceNotifyParties" name="Notify respondent solicitor 1 (CC)" camunda:type="external" camunda:topic="processCaseEvent">
+    <bpmn:serviceTask id="DefendantResponseSpecOneRespRespondedNotifyParties" name="Notify respondent solicitor 1 (CC)" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
           <camunda:inputParameter name="caseEvent">NOTIFY_EVENT</camunda:inputParameter>
@@ -132,10 +132,10 @@
       <bpmn:outgoing>Flow_04pl7l1</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_0ihhzy4" sourceRef="NotifyRoboticsOnContinuousFeed" targetRef="DefendantResponseSpecFullDefenceFullPartAdmitNotifyParties" />
-    <bpmn:sequenceFlow id="Flow_1foo1br" sourceRef="DefendantResponseSpecLipvLRFullOrPartAdmit" targetRef="DefendantResponseUnspecFullDefenceNotifyParties" />
+    <bpmn:sequenceFlow id="Flow_1foo1br" sourceRef="DefendantResponseSpecLipvLRFullOrPartAdmit" targetRef="DefendantResponseSpecOneRespRespondedNotifyParties" />
     <bpmn:sequenceFlow id="Flow_17h58ro" sourceRef="Activity_0ncmkab" targetRef="DefendantResponseSpecLipvLRFullOrPartAdmit" />
-    <bpmn:sequenceFlow id="Flow_04pl7l1" sourceRef="DefendantResponseSpecFullDefenceFullPartAdmitNotifyParties" targetRef="DefendantResponseUnspecFullDefenceNotifyParties" />
-    <bpmn:sequenceFlow id="Flow_05fanh8" sourceRef="DefendantResponseUnspecFullDefenceNotifyParties" targetRef="GenerateDashboardNotificationsDefendantResponse" />
+    <bpmn:sequenceFlow id="Flow_04pl7l1" sourceRef="DefendantResponseSpecFullDefenceFullPartAdmitNotifyParties" targetRef="DefendantResponseSpecOneRespRespondedNotifyParties" />
+    <bpmn:sequenceFlow id="Flow_05fanh8" sourceRef="DefendantResponseSpecOneRespRespondedNotifyParties" targetRef="GenerateDashboardNotificationsDefendantResponse" />
   </bpmn:process>
   <bpmn:message id="Message_0slk3de" />
   <bpmn:error id="Error_0t2ju7k" name="StartBusinessAbort" errorCode="ABORT" />
@@ -176,7 +176,7 @@
       <bpmndi:BPMNShape id="Activity_12h8f4v_di" bpmnElement="UpdateClaimWithApplicationStatus">
         <dc:Bounds x="910" y="140" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_0d29bxu" bpmnElement="DefendantResponseUnspecFullDefenceNotifyParties">
+      <bpmndi:BPMNShape id="BPMNShape_0d29bxu" bpmnElement="DefendantResponseSpecOneRespRespondedNotifyParties">
         <dc:Bounds x="1330" y="140" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0oq939d_di" bpmnElement="DefendantResponseSpecLipvLRFullOrPartAdmit">

--- a/src/test/java/uk/gov/hmcts/reform/civil/bpmn/UploadTranslatedSealedFormForLipVsLrTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bpmn/UploadTranslatedSealedFormForLipVsLrTest.java
@@ -110,7 +110,7 @@ public class UploadTranslatedSealedFormForLipVsLrTest extends BpmnBaseTest {
             notifyRespondent,
             PROCESS_CASE_EVENT,
             "NOTIFY_EVENT",
-            "DefendantResponseUnspecFullDefenceNotifyParties",
+            "DefendantResponseSpecOneRespRespondedNotifyParties",
             variables
         );
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSCCI-4218


### Change description ###
Use DefendantResponseSpecOneRespRespondedNotifyParties instead of DefendantResponseUnspecFullDefenceNotifyParties in upload_translated_defendant_sealed_form.bpmn


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
